### PR TITLE
Search records matching any word in the search terms

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -223,6 +223,29 @@ PostgreSQL full text search also support multiple dictionaries for stemming. You
   BoringTweet.kinda_matching("sleeping") # => [sleepy, sleeping, sleeper]
   BoringTweet.literally_matching("sleeping") # => [sleeping]
 
+===== :any_word
+
+Setting this attribute to true will perform a search which will return all models containing any word in the search terms.
+
+  class Number < ActiveRecord::Base
+    include PgSearch
+    pg_search_scope :search_any_word,
+                    :against => :text,
+                    :using => {
+                      :tsearch => {:any_word => true}
+                    }
+
+    pg_search_scope :search_all_words,
+                    :against => :text
+  end
+
+  one = Number.create! :text => 'one'
+  two = Number.create! :text => 'two'
+  three = Number.create! :text => 'three'
+
+  Number.search_any_word('one two three') # => [one, two, three]
+  Number.search_all_words('one two three') # => []
+
 ==== :dmetaphone (Double Metaphone soundalike search)
 
 {Double Metaphone}[http://en.wikipedia.org/wiki/Double_Metaphone] is an algorithm for matching words that sound alike even if they are spelled very differently. For example, "Geoff" and "Jeff" sound identical and thus match. Currently, this is not a true double-metaphone, as only the first metaphone is used for searching.
@@ -302,7 +325,7 @@ Ignoring accents uses the {unaccent contrib package}[http://www.postgresql.org/d
 == ATTRIBUTIONS
 
 PgSearch would not have been possible without inspiration from
-{texticle}[https://github.com/tenderlove/texticle]. Thanks to 
+{texticle}[https://github.com/tenderlove/texticle]. Thanks to
 {Aaron Patterson}[http://tenderlovemaking.com/]!
 
 == CONTRIBUTIONS AND FEEDBACK

--- a/lib/pg_search/features/tsearch.rb
+++ b/lib/pg_search/features/tsearch.rb
@@ -46,7 +46,7 @@ module PgSearch
           tsquery_sql = "#{tsquery_sql} || #{connection.quote(':*')}" if @options[:prefix]
 
           "to_tsquery(:dictionary, #{tsquery_sql})"
-        end.join(" && ")
+        end.join(@options[:any_word] ? ' || ' : ' && ')
       end
 
       def tsdocument
@@ -55,7 +55,7 @@ module PgSearch
           search_column.weight.nil? ? tsvector : "setweight(#{tsvector}, #{connection.quote(search_column.weight)})"
         end.join(" || ")
       end
-      
+
       # From http://www.postgresql.org/docs/8.3/static/textsearch-controls.html
       #   0 (the default) ignores the document length
       #   1 divides the rank by 1 + the logarithm of the document length


### PR DESCRIPTION
This patch allows to search all records containin any single word in the search terms when using the tsearch search feature.
