### PR TITLE
Fixing syntax error

### DIFF
--- a/lib/pg_search/tasks.rb
+++ b/lib/pg_search/tasks.rb
@@ -4,7 +4,7 @@ require 'pg_search'
 namespace :pg_search do
   namespace :multisearch do
     desc "Rebuild PgSearch multisearch records for MODEL"
-    task rebuild: :environment do
+    task :rebuild => :environment do
       raise "must set MODEL=<model name>" unless ENV["MODEL"]
       model_class = ENV["MODEL"].classify.constantize
       PgSearch::Multisearch.rebuild(model_class)


### PR DESCRIPTION
Just started using this gem a few minutes ago and I was getting a syntax error when trying to run rake pg_search:migration:multisearch
