### PR TITLE
Documentation Update: rake pg_search:multisearch:rebuild

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -105,7 +105,7 @@ To remove all of the documents for a given class, you can simply delete all of t
 
 Run this Rake task to regenerate all of the documents for a given class.
 
- $ rake pg_search:multisearch:rebuild CLASS=BlogPost
+ $ rake pg_search:multisearch:rebuild MODEL=BlogPost
 
 Currently this is only supported for :against methods that directly map to Active Record attributes. Until that is fixed, you could also manually rebuild all of the documents.
 


### PR DESCRIPTION
The command:

rake pg_search:multisearch:rebuild CLASS=User

Results in an error:

rake aborted!
must set MODEL=<model name>

The actual command should be:

rake pg_search:multisearch:rebuild MODEL=User

Just updating the docs.
