### PR TITLE
Timestamps are assigned to pg_search_documents in multisearch rebuild

### DIFF
--- a/lib/pg_search/multisearch.rb
+++ b/lib/pg_search/multisearch.rb
@@ -1,9 +1,11 @@
 module PgSearch
   module Multisearch
     REBUILD_SQL_TEMPLATE = <<-SQL
-INSERT INTO :documents_table (searchable_type, searchable_id, content)
+INSERT INTO :documents_table (searchable_type, searchable_id, created_at, updated_at, content)
   SELECT :model_name AS searchable_type,
          :model_table.id AS searchable_id,
+         ':current_time' AS created_at,
+         ':current_time' AS updated_at,
          (
            :content_expressions
          ) AS content
@@ -41,6 +43,8 @@ SQL
           ":model_table", model.quoted_table_name
         ).gsub(
           ":documents_table", PgSearch::Document.quoted_table_name
+        ).gsub(
+          ":current_time", Time.now.to_s
         )
       end
     end

--- a/spec/pg_search/multisearch_spec.rb
+++ b/spec/pg_search/multisearch_spec.rb
@@ -20,6 +20,10 @@ describe PgSearch::Multisearch do
   end
 
   describe ".rebuild_sql" do
+    before do
+        @time = "2012-03-30 12:52:03 -0700"
+        Time.stub(:now){@time}
+    end
     context "with one attribute" do
       it "should generate the proper SQL code" do
         model = MultisearchableModel
@@ -28,9 +32,11 @@ describe PgSearch::Multisearch do
         model.multisearchable :against => :title
 
         expected_sql = <<-SQL
-INSERT INTO #{PgSearch::Document.quoted_table_name} (searchable_type, searchable_id, content)
+INSERT INTO #{PgSearch::Document.quoted_table_name} (searchable_type, searchable_id, created_at, updated_at, content)
   SELECT #{connection.quote(model.name)} AS searchable_type,
          #{model.quoted_table_name}.id AS searchable_id,
+         '#{@time}' AS created_at,
+         '#{@time}' AS updated_at,
          (
            coalesce(#{model.quoted_table_name}.title, '')
          ) AS content
@@ -49,9 +55,11 @@ SQL
         model.multisearchable :against => [:title, :content]
 
         expected_sql = <<-SQL
-INSERT INTO #{PgSearch::Document.quoted_table_name} (searchable_type, searchable_id, content)
+INSERT INTO #{PgSearch::Document.quoted_table_name} (searchable_type, searchable_id, created_at, updated_at, content)
   SELECT #{connection.quote(model.name)} AS searchable_type,
          #{model.quoted_table_name}.id AS searchable_id,
+         '#{@time}' AS created_at,
+         '#{@time}' AS updated_at,
          (
            coalesce(#{model.quoted_table_name}.title, '') || ' ' || coalesce(#{model.quoted_table_name}.content, '')
          ) AS content


### PR DESCRIPTION
Rails' timestamps migration helper now defaults to :null => false. This previously caused the multisearch rebuild rake tast to throw a not-null violation as it hasn't been assigning timestamps. 

This simply adds the assignment of these timestamps, as the current time, to the sql injection statement in the rake task.

Alternative solution could be to amend the migration to create null-friendly timestamp columns, however assigning timestamps from the beginning seems the better way to go.

Relates to this issue:
https://github.com/Casecommons/pg_search/issues/27
