### PR TITLE
Fixes a syntax error.

### DIFF
--- a/lib/pg_search/tasks.rb
+++ b/lib/pg_search/tasks.rb
@@ -75,7 +75,7 @@ class AddPgSearchDmetaphoneSupportFunctions < ActiveRecord::Migration
       if ActiveRecord::Base.connection.send(:postgresql_version) < 80400
         ActiveRecord::Base.connection.execute(<<-SQL)
           #{uninstall_unnest_sql}
-        end
+        SQL
       end
     end
   end


### PR DESCRIPTION
Ran across this guy after running

```
bin/rake pg_search:migration:dmetaphone
bin/rake db:migrate
```

But this should fix it.
