### PR TITLE
Fix for #31

### DIFF
--- a/lib/pg_search/multisearch.rb
+++ b/lib/pg_search/multisearch.rb
@@ -4,11 +4,11 @@ module PgSearch
 INSERT INTO :documents_table (searchable_type, searchable_id, content, created_at, updated_at)
   SELECT :model_name AS searchable_type,
          :model_table.id AS searchable_id,
-         :current_time AS created_at,
-         :current_time AS updated_at,
          (
            :content_expressions
-         ) AS content
+         ) AS content,
+         :current_time AS created_at,
+         :current_time AS updated_at
   FROM :model_table
 SQL
 

--- a/spec/pg_search/multisearch_spec.rb
+++ b/spec/pg_search/multisearch_spec.rb
@@ -37,11 +37,11 @@ describe PgSearch::Multisearch do
 INSERT INTO #{PgSearch::Document.quoted_table_name} (searchable_type, searchable_id, content, created_at, updated_at)
   SELECT #{connection.quote(model.name)} AS searchable_type,
          #{model.quoted_table_name}.id AS searchable_id,
-         #{connection.quote(connection.quoted_date(now))} AS created_at,
-         #{connection.quote(connection.quoted_date(now))} AS updated_at,
          (
            coalesce(#{model.quoted_table_name}.title, '')
-         ) AS content
+         ) AS content,
+         #{connection.quote(connection.quoted_date(now))} AS created_at,
+         #{connection.quote(connection.quoted_date(now))} AS updated_at
   FROM #{model.quoted_table_name}
 SQL
 
@@ -60,11 +60,11 @@ SQL
 INSERT INTO #{PgSearch::Document.quoted_table_name} (searchable_type, searchable_id, content, created_at, updated_at)
   SELECT #{connection.quote(model.name)} AS searchable_type,
          #{model.quoted_table_name}.id AS searchable_id,
-         #{connection.quote(connection.quoted_date(now))} AS created_at,
-         #{connection.quote(connection.quoted_date(now))} AS updated_at,
          (
            coalesce(#{model.quoted_table_name}.title, '') || ' ' || coalesce(#{model.quoted_table_name}.content, '')
-         ) AS content
+         ) AS content,
+         #{connection.quote(connection.quoted_date(now))} AS created_at,
+         #{connection.quote(connection.quoted_date(now))} AS updated_at
   FROM #{model.quoted_table_name}
 SQL
 


### PR DESCRIPTION
The SQL for rebuilding the multisearch index was slightly off - the order matters in an INSERT INTO ... SELECT construct.
This patch should fix the issue, the indexes are rebuilt correctly now. 
