### PR TITLE
Remove autoloading of scope class.

### DIFF
--- a/lib/pg_search.rb
+++ b/lib/pg_search.rb
@@ -9,7 +9,6 @@ module PgSearch
   autoload :Multisearch, "pg_search/multisearch"
   autoload :Multisearchable, "pg_search/multisearchable"
   autoload :Normalizer, "pg_search/normalizer"
-  autoload :Scope, "pg_search/scope"
   autoload :ScopeOptions, "pg_search/scope_options"
   autoload :VERSION, "pg_search/version"
 


### PR DESCRIPTION
Hi Grant,

Gem version 0.5.5 & 0.5.6 are broken due to loading of non-existent `pg_search/scope` file. This unfortunately prevents the Rails (v 3.2.8)  server from booting as it eagerly loads all dependencies in dev mode. I've rectified this in this patch, please could you let me know when you intend to release a new version?

Anyways, thanks a ton for this awesome gem and keep up good work.

P  
