### PR TITLE
Work around protected sanitize_sql_array in Rails 4 for now.

### DIFF
--- a/lib/pg_search/scope_options.rb
+++ b/lib/pg_search/scope_options.rb
@@ -4,6 +4,8 @@ require "active_support/core_ext/module/delegation"
 
 module PgSearch
   class ScopeOptions
+    include ActiveRecord::Sanitization::ClassMethods
+
     attr_reader :config, :feature_options
 
     def initialize(config)
@@ -18,7 +20,7 @@ module PgSearch
 
     private
 
-    delegate :connection, :quoted_table_name, :sanitize_sql_array, :to => :@model
+    delegate :connection, :quoted_table_name, :to => :@model
 
     def conditions
       config.features.map do |feature_name, feature_options|


### PR DESCRIPTION
This should silence the deprecation warning in Rails 3.x as well.
