### PR TITLE
freeze i18n at <=0.6.1

### DIFF
--- a/pg_search.gemspec
+++ b/pg_search.gemspec
@@ -20,4 +20,5 @@ Gem::Specification.new do |s|
 
   s.add_dependency 'activerecord', '>=3'
   s.add_dependency 'activesupport', '>=3'
+  s.add_dependency 'i18n', '<=0.6.1'
 end


### PR DESCRIPTION
Due to https://github.com/svenfuchs/i18n/issues/192
i18n 0.6.2 breaks ruby 1.8 compat

Thoughts?
