### PR TITLE
use i18n < 0.6.2 or > 0.6.2

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,7 @@ source "http://rubygems.org"
 
 gemspec
 
+gem "i18n", '~> 0.6', '>= 0.6.2'
 gem "rake"
 gem "rdoc"
 gem "pry"


### PR DESCRIPTION
Due to https://github.com/svenfuchs/i18n/issues/192
i18n 0.6.2 breaks ruby 1.8 compat
