### PR TITLE
Renamed Document class to SearchDocument to avoid common conflicts with AR models that use Paperclip

### DIFF
--- a/CHANGELOG.rdoc
+++ b/CHANGELOG.rdoc
@@ -60,7 +60,7 @@
 
 * Fix Active Record 3.2 deprecation warnings. (Steven Harman)
 
-* Fix issue with undefined logger when PgSearch::Document.search is already defined.
+* Fix issue with undefined logger when PgSearch::SearchDocument.search is already defined.
 
 == 0.4
 

--- a/README.rdoc
+++ b/README.rdoc
@@ -75,7 +75,7 @@ To add a model to the global search index for your application, call multisearch
 
 If this model already has existing records, you will need to reindex this model to get existing records into the pg_search_documents table. See the rebuild task below.
 
-Whenever a record is created, updated, or destroyed, an Active Record callback will fire, leading to the creation of a corresponding PgSearch::Document record in the pg_search_documents table. The :against option can be one or several methods which will be called on the record to generate its search text.
+Whenever a record is created, updated, or destroyed, an Active Record callback will fire, leading to the creation of a corresponding PgSearch::SearchDocument record in the pg_search_documents table. The :against option can be one or several methods which will be called on the record to generate its search text.
 
 You can also pass a Proc or method name to call to determine whether or not a particular record should be included.
 
@@ -123,20 +123,20 @@ Note that the Proc or method name is called in an after_save hook. This means th
 
 ==== Multi-search associations
 
-Two associations are built automatically. On the original record, there is a has_one :pg_search_document association pointing to the PgSearch::Document record, and on the PgSearch::Document record there is a belongs_to :searchable polymorphic association pointing back to the original record.
+Two associations are built automatically. On the original record, there is a has_one :pg_search_document association pointing to the PgSearch::SearchDocument record, and on the PgSearch::SearchDocument record there is a belongs_to :searchable polymorphic association pointing back to the original record.
 
  odyssey = EpicPoem.create!(:title => "Odyssey", :author => "Homer")
- search_document = odyssey.pg_search_document #=> PgSearch::Document instance
+ search_document = odyssey.pg_search_document #=> PgSearch::SearchDocument instance
  search_document.searchable #=> #<EpicPoem id: 1, title: "Odyssey", author: "Homer">
 
 ==== Searching in the global search index
 
-To fetch the PgSearch::Document entries for all of the records that match a given query, use PgSearch.multisearch.
+To fetch the PgSearch::SearchDocument entries for all of the records that match a given query, use PgSearch.multisearch.
 
  odyssey = EpicPoem.create!(:title => "Odyssey", :author => "Homer")
  rose = Flower.create!(:color => "Red")
- PgSearch.multisearch("Homer") #=> [#<PgSearch::Document searchable: odyssey>]
- PgSearch.multisearch("Red") #=> [#<PgSearch::Document searchable: rose>]
+ PgSearch.multisearch("Homer") #=> [#<PgSearch::SearchDocument searchable: odyssey>]
+ PgSearch.multisearch("Red") #=> [#<PgSearch::SearchDocument searchable: rose>]
 
 ==== Chaining method calls onto the results
 
@@ -164,9 +164,9 @@ If you change the :against option on a class, add multisearchable to a class tha
 
 The index can also become out-of-sync if you ever modify records in a way that does not trigger Active Record callbacks. For instance, the #update_attribute instance method and the .update_all class method both skip callbacks and directly modify the database.
 
-To remove all of the documents for a given class, you can simply delete all of the PgSearch::Document records.
+To remove all of the documents for a given class, you can simply delete all of the PgSearch::SearchDocument records.
 
- PgSearch::Document.delete_all(:searchable_type => "Animal")
+ PgSearch::SearchDocument.delete_all(:searchable_type => "Animal")
 
 To regenerate the documents for a given class, run:
 
@@ -182,7 +182,7 @@ A second optional argument can be passed to specify the PostgreSQL schema search
 
 For models that are multisearchable :against methods that directly map to Active Record attributes, an efficient single SQL statement is run to update the pg_search_documents table all at once. However, if you call any dynamic methods in :against, the following strategy will be used:
 
- PgSearch::Document.delete_all(:searchable_type => "Ingredient")
+ PgSearch::SearchDocument.delete_all(:searchable_type => "Ingredient")
  Ingredient.find_each { |record| record.update_pg_search_document }
 
 You can also provide a custom implementation for rebuilding the documents by adding a class method called `rebuild_pg_search_documents` to your model.

--- a/lib/pg_search.rb
+++ b/lib/pg_search.rb
@@ -4,7 +4,7 @@ require "active_support/core_ext/module/attribute_accessors"
 
 module PgSearch
   autoload :Configuration, "pg_search/configuration"
-  autoload :Document, "pg_search/document"
+  autoload :SearchDocument, "pg_search/search_document"
   autoload :Features, "pg_search/features"
   autoload :Multisearch, "pg_search/multisearch"
   autoload :Multisearchable, "pg_search/multisearchable"
@@ -57,7 +57,7 @@ module PgSearch
 
   class << self
     def multisearch(*args)
-      PgSearch::Document.search(*args)
+      PgSearch::SearchDocument.search(*args)
     end
 
     def disable_multisearch

--- a/lib/pg_search/multisearch.rb
+++ b/lib/pg_search/multisearch.rb
@@ -5,7 +5,7 @@ module PgSearch
     class << self
       def rebuild(model, clean_up=true)
         model.transaction do
-          PgSearch::Document.where(:searchable_type => model.name).delete_all if clean_up
+          PgSearch::SearchDocument.where(:searchable_type => model.name).delete_all if clean_up
           Rebuilder.new(model).rebuild
         end
       end

--- a/lib/pg_search/multisearch/rebuilder.rb
+++ b/lib/pg_search/multisearch/rebuilder.rb
@@ -69,7 +69,7 @@ SQL
       end
 
       def documents_table
-        PgSearch::Document.quoted_table_name
+        PgSearch::SearchDocument.quoted_table_name
       end
 
       def current_time

--- a/lib/pg_search/multisearchable.rb
+++ b/lib/pg_search/multisearchable.rb
@@ -8,7 +8,7 @@ module PgSearch
     included do
       has_one :pg_search_document,
         :as => :searchable,
-        :class_name => "PgSearch::Document",
+        :class_name => "PgSearch::SearchDocument",
         :dependent => :delete
 
       after_save :update_pg_search_document,

--- a/lib/pg_search/search_document.rb
+++ b/lib/pg_search/search_document.rb
@@ -1,7 +1,7 @@
 require "logger"
 
 module PgSearch
-  class Document < ActiveRecord::Base
+  class SearchDocument < ActiveRecord::Base
     include PgSearch
     self.table_name = 'pg_search_documents'
     belongs_to :searchable, :polymorphic => true

--- a/lib/pg_search/tasks.rb
+++ b/lib/pg_search/tasks.rb
@@ -10,7 +10,7 @@ You must pass a model as an argument.
 Example: rake pg_search:multisearch:rebuild[BlogPost]
       MESSAGE
       model_class = args.model.classify.constantize
-      connection = PgSearch::Document.connection
+      connection = PgSearch::SearchDocument.connection
       original_schema_search_path = connection.schema_search_path
       begin
         connection.schema_search_path = args.schema if args.schema

--- a/spec/pg_search/document_spec.rb
+++ b/spec/pg_search/document_spec.rb
@@ -1,6 +1,6 @@
 require "spec_helper"
 
-describe PgSearch::Document do
+describe PgSearch::SearchDocument do
   with_table "pg_search_documents", {}, &DOCUMENTS_SCHEMA
 
   with_model :Searchable do
@@ -16,7 +16,7 @@ describe PgSearch::Document do
   describe "callbacks" do
     describe "before_validation" do
       subject { document }
-      let(:document) { PgSearch::Document.new(:searchable => searchable) }
+      let(:document) { PgSearch::SearchDocument.new(:searchable => searchable) }
       let(:searchable) { Searchable.new }
 
       before do

--- a/spec/pg_search/multisearch_spec.rb
+++ b/spec/pg_search/multisearch_spec.rb
@@ -41,14 +41,14 @@ describe PgSearch::Multisearch do
             VALUES
             ('Bar', 123, 'foo', now(), now());
         SQL
-        PgSearch::Document.count.should == 2
+        PgSearch::SearchDocument.count.should == 2
       end
 
       context "when clean_up is not passed" do
         it "should delete the document for the model" do
           PgSearch::Multisearch.rebuild(model)
-          PgSearch::Document.count.should == 1
-          PgSearch::Document.first.searchable_type.should == "Bar"
+          PgSearch::SearchDocument.count.should == 1
+          PgSearch::SearchDocument.first.searchable_type.should == "Bar"
         end
       end
 
@@ -57,8 +57,8 @@ describe PgSearch::Multisearch do
 
         it "should delete the document for the model" do
           PgSearch::Multisearch.rebuild(model, clean_up)
-          PgSearch::Document.count.should == 1
-          PgSearch::Document.first.searchable_type.should == "Bar"
+          PgSearch::SearchDocument.count.should == 1
+          PgSearch::SearchDocument.first.searchable_type.should == "Bar"
         end
       end
 
@@ -67,7 +67,7 @@ describe PgSearch::Multisearch do
 
         it "should not delete the document for the model" do
           PgSearch::Multisearch.rebuild(model, clean_up)
-          PgSearch::Document.count.should == 2
+          PgSearch::SearchDocument.count.should == 2
         end
       end
 
@@ -87,7 +87,7 @@ describe PgSearch::Multisearch do
           PgSearch::Multisearch.should_not_receive(:rebuild_sql)
           PgSearch::Multisearch.rebuild(model)
 
-          record = PgSearch::Document.find_by_searchable_type_and_searchable_id("Baz", 789)
+          record = PgSearch::SearchDocument.find_by_searchable_type_and_searchable_id("Baz", 789)
           record.content.should == "baz"
         end
       end
@@ -102,7 +102,7 @@ describe PgSearch::Multisearch do
 
       it "should create new documents for the two models" do
         PgSearch::Multisearch.rebuild(model)
-        PgSearch::Document.last(2).map(&:searchable).map(&:title).should =~ new_models.map(&:title)
+        PgSearch::SearchDocument.last(2).map(&:searchable).map(&:title).should =~ new_models.map(&:title)
       end
     end
 
@@ -120,7 +120,7 @@ describe PgSearch::Multisearch do
 
         it "should generate the proper SQL code" do
           expected_sql = <<-SQL
-INSERT INTO #{PgSearch::Document.quoted_table_name} (searchable_type, searchable_id, content, created_at, updated_at)
+INSERT INTO #{PgSearch::SearchDocument.quoted_table_name} (searchable_type, searchable_id, content, created_at, updated_at)
   SELECT #{connection.quote(model.name)} AS searchable_type,
          #{model.quoted_table_name}.id AS searchable_id,
          (
@@ -147,7 +147,7 @@ INSERT INTO #{PgSearch::Document.quoted_table_name} (searchable_type, searchable
 
         it "should generate the proper SQL code" do
           expected_sql = <<-SQL
-INSERT INTO #{PgSearch::Document.quoted_table_name} (searchable_type, searchable_id, content, created_at, updated_at)
+INSERT INTO #{PgSearch::SearchDocument.quoted_table_name} (searchable_type, searchable_id, content, created_at, updated_at)
   SELECT #{connection.quote(model.name)} AS searchable_type,
          #{model.quoted_table_name}.id AS searchable_id,
          (

--- a/spec/pg_search/multisearchable_spec.rb
+++ b/spec/pg_search/multisearchable_spec.rb
@@ -16,15 +16,15 @@ describe PgSearch::Multisearchable do
         let(:record) { ModelThatIsMultisearchable.new }
 
         describe "saving the record" do
-          it "should create a PgSearch::Document record" do
-            expect { record.save! }.to change(PgSearch::Document, :count).by(1)
+          it "should create a PgSearch::SearchDocument record" do
+            expect { record.save! }.to change(PgSearch::SearchDocument, :count).by(1)
           end
 
           context "with multisearch disabled" do
             before { PgSearch.stub(:multisearch_enabled? => false) }
 
-            it "should not create a PgSearch::Document record" do
-              expect { record.save! }.not_to change(PgSearch::Document, :count)
+            it "should not create a PgSearch::SearchDocument record" do
+              expect { record.save! }.not_to change(PgSearch::SearchDocument, :count)
             end
           end
         end
@@ -32,7 +32,7 @@ describe PgSearch::Multisearchable do
         describe "the document" do
           it "should be associated to the record" do
             record.save!
-            newest_pg_search_document = PgSearch::Document.last
+            newest_pg_search_document = PgSearch::SearchDocument.last
             record.pg_search_document.should == newest_pg_search_document
             newest_pg_search_document.searchable.should == record
           end
@@ -51,16 +51,16 @@ describe PgSearch::Multisearchable do
               record.save!
             end
 
-            it "should not create a PgSearch::Document record" do
-              expect { record.save! }.not_to change(PgSearch::Document, :count)
+            it "should not create a PgSearch::SearchDocument record" do
+              expect { record.save! }.not_to change(PgSearch::SearchDocument, :count)
             end
 
             context "with multisearch disabled" do
               before { PgSearch.stub(:multisearch_enabled? => false) }
 
-              it "should not create a PgSearch::Document record" do
+              it "should not create a PgSearch::SearchDocument record" do
                 record.pg_search_document.should_not_receive(:save)
-                expect { record.save! }.not_to change(PgSearch::Document, :count)
+                expect { record.save! }.not_to change(PgSearch::SearchDocument, :count)
               end
             end
           end
@@ -70,15 +70,15 @@ describe PgSearch::Multisearchable do
           before { record.pg_search_document = nil }
 
           describe "saving the record" do
-            it "should create a PgSearch::Document record" do
-              expect { record.save! }.to change(PgSearch::Document, :count).by(1)
+            it "should create a PgSearch::SearchDocument record" do
+              expect { record.save! }.to change(PgSearch::SearchDocument, :count).by(1)
             end
 
             context "with multisearch disabled" do
               before { PgSearch.stub(:multisearch_enabled? => false) }
 
-              it "should not create a PgSearch::Document record" do
-                expect { record.save! }.not_to change(PgSearch::Document, :count)
+              it "should not create a PgSearch::SearchDocument record" do
+                expect { record.save! }.not_to change(PgSearch::SearchDocument, :count)
               end
             end
           end
@@ -89,8 +89,8 @@ describe PgSearch::Multisearchable do
         it "should remove its document" do
           record = ModelThatIsMultisearchable.create!
           document = record.pg_search_document
-          expect { record.destroy }.to change(PgSearch::Document, :count).by(-1)
-          expect { PgSearch::Document.find(document.id) }.to raise_error(ActiveRecord::RecordNotFound)
+          expect { record.destroy }.to change(PgSearch::SearchDocument, :count).by(-1)
+          expect { PgSearch::SearchDocument.find(document.id) }.to raise_error(ActiveRecord::RecordNotFound)
         end
       end
     end
@@ -115,15 +115,15 @@ describe PgSearch::Multisearchable do
             context "when the condition is true" do
               let(:record) { ModelThatIsMultisearchable.new(:multisearchable => true) }
 
-              it "should create a PgSearch::Document record" do
-                expect { record.save! }.to change(PgSearch::Document, :count).by(1)
+              it "should create a PgSearch::SearchDocument record" do
+                expect { record.save! }.to change(PgSearch::SearchDocument, :count).by(1)
               end
 
               context "with multisearch disabled" do
                 before { PgSearch.stub(:multisearch_enabled? => false) }
 
-                it "should not create a PgSearch::Document record" do
-                  expect { record.save! }.not_to change(PgSearch::Document, :count)
+                it "should not create a PgSearch::SearchDocument record" do
+                  expect { record.save! }.not_to change(PgSearch::SearchDocument, :count)
                 end
               end
             end
@@ -131,8 +131,8 @@ describe PgSearch::Multisearchable do
             context "when the condition is false" do
               let(:record) { ModelThatIsMultisearchable.new(:multisearchable => false) }
 
-              it "should not create a PgSearch::Document record" do
-                expect { record.save! }.not_to change(PgSearch::Document, :count)
+              it "should not create a PgSearch::SearchDocument record" do
+                expect { record.save! }.not_to change(PgSearch::SearchDocument, :count)
               end
             end
           end
@@ -151,8 +151,8 @@ describe PgSearch::Multisearchable do
                   record.save!
                 end
 
-                it "should not create a PgSearch::Document record" do
-                  expect { record.save! }.not_to change(PgSearch::Document, :count)
+                it "should not create a PgSearch::SearchDocument record" do
+                  expect { record.save! }.not_to change(PgSearch::SearchDocument, :count)
                 end
               end
 
@@ -166,8 +166,8 @@ describe PgSearch::Multisearchable do
 
                 it "should remove its document" do
                   document = record.pg_search_document
-                  expect { record.save! }.to change(PgSearch::Document, :count).by(-1)
-                  expect { PgSearch::Document.find(document.id) }.to raise_error(ActiveRecord::RecordNotFound)
+                  expect { record.save! }.to change(PgSearch::SearchDocument, :count).by(-1)
+                  expect { PgSearch::SearchDocument.find(document.id) }.to raise_error(ActiveRecord::RecordNotFound)
                 end
               end
 
@@ -177,8 +177,8 @@ describe PgSearch::Multisearchable do
                   record.pg_search_document.should_not_receive(:save)
                 end
 
-                it "should not create a PgSearch::Document record" do
-                  expect { record.save! }.not_to change(PgSearch::Document, :count)
+                it "should not create a PgSearch::SearchDocument record" do
+                  expect { record.save! }.not_to change(PgSearch::SearchDocument, :count)
                 end
               end
             end
@@ -189,15 +189,15 @@ describe PgSearch::Multisearchable do
 
             describe "saving the record" do
               context "when the condition is true" do
-                it "should create a PgSearch::Document record" do
-                  expect { record.save! }.to change(PgSearch::Document, :count).by(1)
+                it "should create a PgSearch::SearchDocument record" do
+                  expect { record.save! }.to change(PgSearch::SearchDocument, :count).by(1)
                 end
 
                 context "with multisearch disabled" do
                   before { PgSearch.stub(:multisearch_enabled? => false) }
 
-                  it "should not create a PgSearch::Document record" do
-                    expect { record.save! }.not_to change(PgSearch::Document, :count)
+                  it "should not create a PgSearch::SearchDocument record" do
+                    expect { record.save! }.not_to change(PgSearch::SearchDocument, :count)
                   end
                 end
               end
@@ -205,8 +205,8 @@ describe PgSearch::Multisearchable do
               context "when the condition is false" do
                 before { record.multisearchable = false }
 
-                it "should not create a PgSearch::Document record" do
-                  expect { record.save! }.not_to change(PgSearch::Document, :count)
+                it "should not create a PgSearch::SearchDocument record" do
+                  expect { record.save! }.not_to change(PgSearch::SearchDocument, :count)
                 end
               end
             end
@@ -218,8 +218,8 @@ describe PgSearch::Multisearchable do
 
           it "should remove its document" do
             document = record.pg_search_document
-            expect { record.destroy }.to change(PgSearch::Document, :count).by(-1)
-            expect { PgSearch::Document.find(document.id) }.to raise_error(ActiveRecord::RecordNotFound)
+            expect { record.destroy }.to change(PgSearch::SearchDocument, :count).by(-1)
+            expect { PgSearch::SearchDocument.find(document.id) }.to raise_error(ActiveRecord::RecordNotFound)
           end
         end
       end
@@ -243,15 +243,15 @@ describe PgSearch::Multisearchable do
             context "when the condition is false" do
               let(:record) { ModelThatIsMultisearchable.new(:not_multisearchable => false) }
 
-              it "should create a PgSearch::Document record" do
-                expect { record.save! }.to change(PgSearch::Document, :count).by(1)
+              it "should create a PgSearch::SearchDocument record" do
+                expect { record.save! }.to change(PgSearch::SearchDocument, :count).by(1)
               end
 
               context "with multisearch disabled" do
                 before { PgSearch.stub(:multisearch_enabled? => false) }
 
-                it "should not create a PgSearch::Document record" do
-                  expect { record.save! }.not_to change(PgSearch::Document, :count)
+                it "should not create a PgSearch::SearchDocument record" do
+                  expect { record.save! }.not_to change(PgSearch::SearchDocument, :count)
                 end
               end
             end
@@ -259,8 +259,8 @@ describe PgSearch::Multisearchable do
             context "when the condition is true" do
               let(:record) { ModelThatIsMultisearchable.new(:not_multisearchable => true) }
 
-              it "should not create a PgSearch::Document record" do
-                expect { record.save! }.not_to change(PgSearch::Document, :count)
+              it "should not create a PgSearch::SearchDocument record" do
+                expect { record.save! }.not_to change(PgSearch::SearchDocument, :count)
               end
             end
           end
@@ -279,8 +279,8 @@ describe PgSearch::Multisearchable do
                   record.save!
                 end
 
-                it "should not create a PgSearch::Document record" do
-                  expect { record.save! }.not_to change(PgSearch::Document, :count)
+                it "should not create a PgSearch::SearchDocument record" do
+                  expect { record.save! }.not_to change(PgSearch::SearchDocument, :count)
                 end
 
                 context "with multisearch disabled" do
@@ -289,8 +289,8 @@ describe PgSearch::Multisearchable do
                     record.pg_search_document.should_not_receive(:save)
                   end
 
-                  it "should not create a PgSearch::Document record" do
-                    expect { record.save! }.not_to change(PgSearch::Document, :count)
+                  it "should not create a PgSearch::SearchDocument record" do
+                    expect { record.save! }.not_to change(PgSearch::SearchDocument, :count)
                   end
                 end
               end
@@ -305,8 +305,8 @@ describe PgSearch::Multisearchable do
 
                 it "should remove its document" do
                   document = record.pg_search_document
-                  expect { record.save! }.to change(PgSearch::Document, :count).by(-1)
-                  expect { PgSearch::Document.find(document.id) }.to raise_error(ActiveRecord::RecordNotFound)
+                  expect { record.save! }.to change(PgSearch::SearchDocument, :count).by(-1)
+                  expect { PgSearch::SearchDocument.find(document.id) }.to raise_error(ActiveRecord::RecordNotFound)
                 end
               end
 
@@ -318,23 +318,23 @@ describe PgSearch::Multisearchable do
 
             describe "saving the record" do
               context "when the condition is false" do
-                it "should create a PgSearch::Document record" do
-                  expect { record.save! }.to change(PgSearch::Document, :count).by(1)
+                it "should create a PgSearch::SearchDocument record" do
+                  expect { record.save! }.to change(PgSearch::SearchDocument, :count).by(1)
                 end
               end
 
               context "when the condition is true" do
                 before { record.not_multisearchable = true }
 
-                it "should not create a PgSearch::Document record" do
-                  expect { record.save! }.not_to change(PgSearch::Document, :count)
+                it "should not create a PgSearch::SearchDocument record" do
+                  expect { record.save! }.not_to change(PgSearch::SearchDocument, :count)
                 end
               end
 
               context "with multisearch disabled" do
                 before { PgSearch.stub(:multisearch_enabled? => false) }
-                it "should not create a PgSearch::Document record" do
-                  expect { record.save! }.not_to change(PgSearch::Document, :count)
+                it "should not create a PgSearch::SearchDocument record" do
+                  expect { record.save! }.not_to change(PgSearch::SearchDocument, :count)
                 end
               end
             end
@@ -345,8 +345,8 @@ describe PgSearch::Multisearchable do
           it "should remove its document" do
             record = ModelThatIsMultisearchable.create!
             document = record.pg_search_document
-            expect { record.destroy }.to change(PgSearch::Document, :count).by(-1)
-            expect { PgSearch::Document.find(document.id) }.to raise_error(ActiveRecord::RecordNotFound)
+            expect { record.destroy }.to change(PgSearch::SearchDocument, :count).by(-1)
+            expect { PgSearch::SearchDocument.find(document.id) }.to raise_error(ActiveRecord::RecordNotFound)
           end
         end
       end
@@ -372,15 +372,15 @@ describe PgSearch::Multisearchable do
             context "when the condition is true" do
               let(:record) { ModelThatIsMultisearchable.new(:multisearchable => true) }
 
-              it "should create a PgSearch::Document record" do
-                expect { record.save! }.to change(PgSearch::Document, :count).by(1)
+              it "should create a PgSearch::SearchDocument record" do
+                expect { record.save! }.to change(PgSearch::SearchDocument, :count).by(1)
               end
 
               context "with multisearch disabled" do
                 before { PgSearch.stub(:multisearch_enabled? => false) }
 
-                it "should not create a PgSearch::Document record" do
-                  expect { record.save! }.not_to change(PgSearch::Document, :count)
+                it "should not create a PgSearch::SearchDocument record" do
+                  expect { record.save! }.not_to change(PgSearch::SearchDocument, :count)
                 end
               end
             end
@@ -388,8 +388,8 @@ describe PgSearch::Multisearchable do
             context "when the condition is false" do
               let(:record) { ModelThatIsMultisearchable.new(:multisearchable => false) }
 
-              it "should not create a PgSearch::Document record" do
-                expect { record.save! }.not_to change(PgSearch::Document, :count)
+              it "should not create a PgSearch::SearchDocument record" do
+                expect { record.save! }.not_to change(PgSearch::SearchDocument, :count)
               end
             end
           end
@@ -408,8 +408,8 @@ describe PgSearch::Multisearchable do
                   record.save!
                 end
 
-                it "should not create a PgSearch::Document record" do
-                  expect { record.save! }.not_to change(PgSearch::Document, :count)
+                it "should not create a PgSearch::SearchDocument record" do
+                  expect { record.save! }.not_to change(PgSearch::SearchDocument, :count)
                 end
 
                 context "with multisearch disabled" do
@@ -418,8 +418,8 @@ describe PgSearch::Multisearchable do
                     record.pg_search_document.should_not_receive(:save)
                   end
 
-                  it "should not create a PgSearch::Document record" do
-                    expect { record.save! }.not_to change(PgSearch::Document, :count)
+                  it "should not create a PgSearch::SearchDocument record" do
+                    expect { record.save! }.not_to change(PgSearch::SearchDocument, :count)
                   end
                 end
               end
@@ -434,8 +434,8 @@ describe PgSearch::Multisearchable do
 
                 it "should remove its document" do
                   document = record.pg_search_document
-                  expect { record.save! }.to change(PgSearch::Document, :count).by(-1)
-                  expect { PgSearch::Document.find(document.id) }.to raise_error(ActiveRecord::RecordNotFound)
+                  expect { record.save! }.to change(PgSearch::SearchDocument, :count).by(-1)
+                  expect { PgSearch::SearchDocument.find(document.id) }.to raise_error(ActiveRecord::RecordNotFound)
                 end
               end
             end
@@ -449,16 +449,16 @@ describe PgSearch::Multisearchable do
                 before { PgSearch.stub(:multisearch_enabled? => true) }
 
                 context "when the condition is true" do
-                  it "should create a PgSearch::Document record" do
-                    expect { record.save! }.to change(PgSearch::Document, :count).by(1)
+                  it "should create a PgSearch::SearchDocument record" do
+                    expect { record.save! }.to change(PgSearch::SearchDocument, :count).by(1)
                   end
                 end
 
                 context "when the condition is false" do
                   before { record.multisearchable = false }
 
-                  it "should not create a PgSearch::Document record" do
-                    expect { record.save! }.not_to change(PgSearch::Document, :count)
+                  it "should not create a PgSearch::SearchDocument record" do
+                    expect { record.save! }.not_to change(PgSearch::SearchDocument, :count)
                   end
                 end
               end
@@ -466,8 +466,8 @@ describe PgSearch::Multisearchable do
               context "with multisearch disabled" do
                 before { PgSearch.stub(:multisearch_enabled? => false) }
 
-                it "should not create a PgSearch::Document record" do
-                  expect { record.save! }.not_to change(PgSearch::Document, :count)
+                it "should not create a PgSearch::SearchDocument record" do
+                  expect { record.save! }.not_to change(PgSearch::SearchDocument, :count)
                 end
               end
             end
@@ -479,8 +479,8 @@ describe PgSearch::Multisearchable do
 
           it "should remove its document" do
             document = record.pg_search_document
-            expect { record.destroy }.to change(PgSearch::Document, :count).by(-1)
-            expect { PgSearch::Document.find(document.id) }.to raise_error(ActiveRecord::RecordNotFound)
+            expect { record.destroy }.to change(PgSearch::SearchDocument, :count).by(-1)
+            expect { PgSearch::SearchDocument.find(document.id) }.to raise_error(ActiveRecord::RecordNotFound)
           end
         end
       end
@@ -504,23 +504,23 @@ describe PgSearch::Multisearchable do
             context "when the condition is true" do
               let(:record) { ModelThatIsMultisearchable.new(:not_multisearchable => true) }
 
-              it "should not create a PgSearch::Document record" do
-                expect { record.save! }.not_to change(PgSearch::Document, :count)
+              it "should not create a PgSearch::SearchDocument record" do
+                expect { record.save! }.not_to change(PgSearch::SearchDocument, :count)
               end
             end
 
             context "when the condition is false" do
               let(:record) { ModelThatIsMultisearchable.new(:not_multisearchable => false) }
 
-              it "should create a PgSearch::Document record" do
-                expect { record.save! }.to change(PgSearch::Document, :count).by(1)
+              it "should create a PgSearch::SearchDocument record" do
+                expect { record.save! }.to change(PgSearch::SearchDocument, :count).by(1)
               end
 
               context "with multisearch disabled" do
                 before { PgSearch.stub(:multisearch_enabled? => false) }
 
-                it "should not create a PgSearch::Document record" do
-                  expect { record.save! }.not_to change(PgSearch::Document, :count)
+                it "should not create a PgSearch::SearchDocument record" do
+                  expect { record.save! }.not_to change(PgSearch::SearchDocument, :count)
                 end
               end
             end
@@ -544,8 +544,8 @@ describe PgSearch::Multisearchable do
 
                 it "should remove its document" do
                   document = record.pg_search_document
-                  expect { record.save! }.to change(PgSearch::Document, :count).by(-1)
-                  expect { PgSearch::Document.find(document.id) }.to raise_error(ActiveRecord::RecordNotFound)
+                  expect { record.save! }.to change(PgSearch::SearchDocument, :count).by(-1)
+                  expect { PgSearch::SearchDocument.find(document.id) }.to raise_error(ActiveRecord::RecordNotFound)
                 end
               end
 
@@ -555,8 +555,8 @@ describe PgSearch::Multisearchable do
                   record.save!
                 end
 
-                it "should not create a PgSearch::Document record" do
-                  expect { record.save! }.not_to change(PgSearch::Document, :count)
+                it "should not create a PgSearch::SearchDocument record" do
+                  expect { record.save! }.not_to change(PgSearch::SearchDocument, :count)
                 end
 
                 context "with multisearch disabled" do
@@ -565,8 +565,8 @@ describe PgSearch::Multisearchable do
                     record.pg_search_document.should_not_receive(:save)
                   end
 
-                  it "should not create a PgSearch::Document record" do
-                    expect { record.save! }.not_to change(PgSearch::Document, :count)
+                  it "should not create a PgSearch::SearchDocument record" do
+                    expect { record.save! }.not_to change(PgSearch::SearchDocument, :count)
                   end
                 end
               end
@@ -583,21 +583,21 @@ describe PgSearch::Multisearchable do
                 context "when the condition is true" do
                   before { record.not_multisearchable = true }
 
-                  it "should not create a PgSearch::Document record" do
-                    expect { record.save! }.not_to change(PgSearch::Document, :count)
+                  it "should not create a PgSearch::SearchDocument record" do
+                    expect { record.save! }.not_to change(PgSearch::SearchDocument, :count)
                   end
                 end
 
                 context "when the condition is false" do
-                  it "should create a PgSearch::Document record" do
-                    expect { record.save! }.to change(PgSearch::Document, :count).by(1)
+                  it "should create a PgSearch::SearchDocument record" do
+                    expect { record.save! }.to change(PgSearch::SearchDocument, :count).by(1)
                   end
 
                   context "with multisearch disabled" do
                     before { PgSearch.stub(:multisearch_enabled? => false) }
 
-                    it "should not create a PgSearch::Document record" do
-                      expect { record.save! }.not_to change(PgSearch::Document, :count)
+                    it "should not create a PgSearch::SearchDocument record" do
+                      expect { record.save! }.not_to change(PgSearch::SearchDocument, :count)
                     end
                   end
                 end
@@ -611,8 +611,8 @@ describe PgSearch::Multisearchable do
 
           it "should remove its document" do
             document = record.pg_search_document
-            expect { record.destroy }.to change(PgSearch::Document, :count).by(-1)
-            expect { PgSearch::Document.find(document.id) }.to raise_error(ActiveRecord::RecordNotFound)
+            expect { record.destroy }.to change(PgSearch::SearchDocument, :count).by(-1)
+            expect { PgSearch::SearchDocument.find(document.id) }.to raise_error(ActiveRecord::RecordNotFound)
           end
         end
       end

--- a/spec/pg_search_spec.rb
+++ b/spec/pg_search_spec.rb
@@ -810,13 +810,13 @@ describe "an ActiveRecord model which includes PgSearch" do
   describe ".multisearch" do
     with_table "pg_search_documents", {}, &DOCUMENTS_SCHEMA
 
-    describe "delegation to PgSearch::Document.search" do
+    describe "delegation to PgSearch::SearchDocument.search" do
       subject { PgSearch.multisearch(query) }
 
       let(:query) { double(:query) }
       let(:relation) { double(:relation) }
       before do
-        PgSearch::Document.should_receive(:search).with(query).and_return(relation)
+        PgSearch::SearchDocument.should_receive(:search).with(query).and_return(relation)
       end
 
       it { should == relation }


### PR DESCRIPTION
Renamed Document class to SearchDocument to avoid common conflicts with AR models that use Paperclip, as per: https://github.com/Casecommons/pg_search/issues/95

Underlying table name is unchanged, so no breaking changes are introduced.
