### PR TITLE
Compacting config.features array to remove Ruby 2.0.0 deprecation warnin...

### DIFF
--- a/lib/pg_search/scope_options.rb
+++ b/lib/pg_search/scope_options.rb
@@ -7,7 +7,7 @@ module PgSearch
     def initialize(config)
       @config = config
       @model = config.model
-      @feature_options = Hash[config.features]
+      @feature_options = Hash[config.features.compact]
     end
 
     def apply(scope)


### PR DESCRIPTION
I've made a small change to fix [the deprecation warning issue](https://github.com/Casecommons/pg_search/issues/89#issuecomment-15095329)

I apologize if I'm not following PR protocol but I've made it on a separate branch. Specs are still green.
