### PR TITLE
Compare protected method list as strings

### DIFF
--- a/lib/pg_search.rb
+++ b/lib/pg_search.rb
@@ -16,7 +16,7 @@ module PgSearch
     def pg_search_scope(name, options)
       scope = PgSearch::Scope.new(name, self, options)
       scope_method =
-        if respond_to?(:scope) && !protected_methods.include?('scope')
+        if respond_to?(:scope) && !protected_methods.map(&:to_s).include?('scope')
           :scope # ActiveRecord 3.x
         else
           :named_scope # ActiveRecord 2.x


### PR DESCRIPTION
Fixes #90, a compatibility issue between Ruby 1.8.7 and Ruby 1.9.3 that would cause a Rails 2 app to try to use the Rails 3 method of wrapping scope, which would prevent `pg_search_scope` from working.

Ruby 1.9.3 returns symbols from enumerations, whereas 1.8.7 would return strings.
