### PR TITLE
Mark dynamic document

### DIFF
--- a/lib/pg_search/multisearch/rebuilder.rb
+++ b/lib/pg_search/multisearch/rebuilder.rb
@@ -13,7 +13,7 @@ module PgSearch
       def rebuild
         if model.respond_to?(:rebuild_pg_search_documents)
           model.rebuild_pg_search_documents
-        elsif model.pg_search_multisearchable_options.key?(:if) || model.pg_search_multisearchable_options.key?(:unless)
+        elsif dynamic_strategy?
           model.find_each { |record| record.update_pg_search_document }
         else
           model.connection.execute(rebuild_sql)
@@ -74,6 +74,12 @@ module PgSearch
 
       def current_time
         connection.quote(connection.quoted_date(@time_source.call))
+      end
+
+      def dynamic_strategy?
+        model.pg_search_multisearchable_options.key?(:if) ||
+        model.pg_search_multisearchable_options.key?(:unless) ||
+        model.pg_search_multisearchable_options[:dynamic]
       end
     end
   end

--- a/spec/lib/pg_search/multisearch/rebuilder_spec.rb
+++ b/spec/lib/pg_search/multisearch/rebuilder_spec.rb
@@ -200,11 +200,11 @@ describe PgSearch::Multisearch::Rebuilder do
       end
 
       context "when multisearchable is dynamic" do
-        context "implicitly" do
+        context "explicitly via :dynamic => true" do
           with_model :Model do
             model do
               include PgSearch
-              multisearchable :against => :dynamic_method
+              multisearchable :against => :dynamic_method, :dynamic => true
 
               def dynamic_method
                 'not a column'

--- a/spec/lib/pg_search/multisearch/rebuilder_spec.rb
+++ b/spec/lib/pg_search/multisearch/rebuilder_spec.rb
@@ -198,6 +198,43 @@ describe PgSearch::Multisearch::Rebuilder do
           end
         end
       end
+
+      context "when multisearchable is dynamic" do
+        context "implicitly" do
+          with_model :Model do
+            model do
+              include PgSearch
+              multisearchable :against => :dynamic_method
+
+              def dynamic_method
+                'not a column'
+              end
+            end
+          end
+
+          it "calls update_pg_search_document on each record" do
+            record = Model.create!
+
+            rebuilder = PgSearch::Multisearch::Rebuilder.new(Model)
+
+            # stub respond_to? to return false since should_not_receive defines the method
+            original_respond_to = Model.method(:respond_to?)
+            Model.stub(:respond_to?) do |method_name, *args|
+              if method_name == :rebuild_pg_search_documents
+                false
+              else
+                original_respond_to.call(method_name, *args)
+              end
+            end
+            Model.should_not_receive(:rebuild_pg_search_documents)
+
+            rebuilder.rebuild
+
+            record.pg_search_document.should be_present
+            record.pg_search_document.content.should == 'not a column'
+          end
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
As stated by the README,

> However, if you call any dynamic methods in :against, the following strategy will be used:
> 
>     PgSearch::Document.delete_all(:searchable_type => "Ingredient")
>     Ingredient.find_each { |record| record.update_pg_search_document }

all it takes for `pg_search` to use that strategy instead of the efficient SQL is using a dynamic method in `:against`, Well, I hit #70. I played a little with this

    (columns.uniq.map(&:to_s) - model.column_names).any?

as a method of detecting "columns" from `:against` that aren't database columns, but I broke some tests so instead I tried a more explicit approach. It would be awesome to autodetect it really, but it's nice to have a way to reuse the code inside `pg_search`.