### PR TITLE
Normalize trigram query and document as Arel nodes

### DIFF
--- a/lib/pg_search/features/trigram.rb
+++ b/lib/pg_search/features/trigram.rb
@@ -3,7 +3,7 @@ module PgSearch
     class Trigram < Feature
       def conditions
         Arel::Nodes::Grouping.new(
-          Arel::Nodes::InfixOperation.new("%", normalized_document, normalize(query))
+          Arel::Nodes::InfixOperation.new("%", normalized_document, normalized_query)
         )
       end
 
@@ -13,7 +13,7 @@ module PgSearch
             "similarity",
             [
               normalized_document,
-              normalize(query)
+              normalized_query
             ]
           )
         )
@@ -22,7 +22,12 @@ module PgSearch
       private
 
       def normalized_document
-        Arel::Nodes::Grouping.new(normalize(Arel.sql(document)))
+        Arel::Nodes::Grouping.new(Arel.sql(normalize(document)))
+      end
+
+      def normalized_query
+        sanitized_query = connection.quote(query)
+        Arel.sql(normalize(sanitized_query))
       end
     end
   end


### PR DESCRIPTION
When trying to use `ingnoring: :accents` with `using: :trigrams` my searches were not returning expected results. After inspecting the generated SQL I found this was to due to incorrect escaping of the trigram terms.

We need to normalize the Trigram's query and document, making sure they are Arel nodes, not strings so that the `Arel::Nodes::InfixOperation.new` correctly puts them together with the `'%'` operator. Without this change, they are incorrectly escaped as:

``` sql
(
  ('unaccent(coalesce("pg_search_documents"."content"::text, ''''))')
  %
  'unaccent(Cambonator Doppelbock)'
)
```

The correct escaping is:

``` sql
(
  (unaccent(coalesce("pg_search_documents"."content"::text, '')))
  %
  unaccent('Cambonator Doppelbock')
)

```
