### PR TITLE
Remove ActiveSupport::Concern

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ https://github.com/Casecommons/pg_search/tree/0.6-stable
 To add PgSearch to an Active Record model, simply include the PgSearch module.
 
     class Shape < ActiveRecord::Base
-      include PgSearch
+      extend PgSearch
     end
 
 ### Multi-search vs. search scopes
@@ -119,12 +119,12 @@ To add a model to the global search index for your application, call
 multisearchable in its class definition.
 
     class EpicPoem < ActiveRecord::Base
-      include PgSearch
+      extend PgSearch
       multisearchable :against => [:title, :author]
     end
 
     class Flower < ActiveRecord::Base
-      include PgSearch
+      extend PgSearch
       multisearchable :against => :color
     end
 
@@ -142,13 +142,13 @@ You can also pass a Proc or method name to call to determine whether or not a
 particular record should be included.
 
     class Convertible < ActiveRecord::Base
-      include PgSearch
+      extend PgSearch
       multisearchable :against => [:make, :model],
                       :if => :available_in_red?
     end
 
     class Jalopy < ActiveRecord::Base
-      include PgSearch
+      extend PgSearch
       multisearchable :against => [:make, :model],
                       :if => lambda { |record| record.model_year > 1970 }
     end
@@ -160,7 +160,7 @@ won't get listed in global search at all until it is touched again after the
 timestamp.
 
     class AntipatternExample
-      include PgSearch
+      extend PgSearch
       multisearchable :against => [:contents],
                       :if => :published?
 
@@ -330,7 +330,7 @@ search against.
 To search against a column, pass a symbol as the :against option.
 
     class BlogPost < ActiveRecord::Base
-      include PgSearch
+      extend PgSearch
       pg_search_scope :search_by_title, :against => :title
     end
 
@@ -346,7 +346,7 @@ It takes one parameter, a search query string.
 Just pass an Array if you'd like to search more than one column.
 
     class Person < ActiveRecord::Base
-      include PgSearch
+      extend PgSearch
       pg_search_scope :search_by_full_name, :against => [:first_name, :last_name]
     end
 
@@ -369,7 +369,7 @@ necessary have to be dynamic. You could choose to hard-code it to a specific
 value if you wanted.
 
     class Person < ActiveRecord::Base
-      include PgSearch
+      extend PgSearch
       pg_search_scope :search_by_name, lambda do |name_part, query|
         raise ArgumentError unless [:first, :last].include?(name_part)
         {
@@ -414,7 +414,7 @@ setting up a series of :through associations to point all the way through.
     end
 
     class Salami < ActiveRecord::Base
-      include PgSearch
+      extend PgSearch
 
       belongs_to :cracker
       has_many :cheeses, :through => :cracker
@@ -447,7 +447,7 @@ If you pass the :using option to pg_search_scope, you can choose alternative
 search techniques.
 
     class Beer < ActiveRecord::Base
-      include PgSearch
+      extend PgSearch
       pg_search_scope :search_name, :against => :name, :using => [:tsearch, :trigram, :dmetaphone]
     end
 
@@ -472,7 +472,7 @@ the following example, the title is the most important, followed by the
 subtitle, and finally the content.
 
     class NewsArticle < ActiveRecord::Base
-      include PgSearch
+      extend PgSearch
       pg_search_scope :search_full_text, :against => {
         :title => 'A',
         :subtitle => 'B',
@@ -485,7 +485,7 @@ that responds to #each and yields either a single symbol or a symbol and a
 weight. If you omit the weight, a default will be used.
 
     class NewsArticle < ActiveRecord::Base
-      include PgSearch
+      extend PgSearch
       pg_search_scope :search_full_text, :against => [
         [:title, 'A'],
         [:subtitle, 'B'],
@@ -494,7 +494,7 @@ weight. If you omit the weight, a default will be used.
     end
 
     class NewsArticle < ActiveRecord::Base
-      include PgSearch
+      extend PgSearch
       pg_search_scope :search_full_text, :against => [
         [:title, 'A'],
         {:subtitle => 'B'},
@@ -510,7 +510,7 @@ is a :tsearch-specific option, you should pass it to :tsearch directly, as
 shown in the following example.
 
     class Superhero < ActiveRecord::Base
-      include PgSearch
+      extend PgSearch
       pg_search_scope :whose_name_starts_with,
                       :against => :name,
                       :using => {
@@ -536,7 +536,7 @@ not do any stemming. If you don't specify a dictionary, the "simple"
 dictionary will be used.
 
     class BoringTweet < ActiveRecord::Base
-      include PgSearch
+      extend PgSearch
       pg_search_scope :kinda_matching,
                       :against => :text,
                       :using => {
@@ -578,7 +578,7 @@ their numbers together.
 (e.g. to use algorithms 1, 8, and 32, you would pass 1 + 8 + 32 = 41)
 
     class BigLongDocument < ActiveRecord::Base
-      include PgSearch
+      extend PgSearch
       pg_search_scope :regular_search,
                       :against => :text
 
@@ -600,7 +600,7 @@ Setting this attribute to true will perform a search which will return all
 models containing any word in the search terms.
 
     class Number < ActiveRecord::Base
-      include PgSearch
+      extend PgSearch
       pg_search_scope :search_any_word,
                       :against => :text,
                       :using => {
@@ -638,7 +638,7 @@ generate and run a migration for this, run:
 The following example shows how to use :dmetaphone.
 
     class Word < ActiveRecord::Base
-      include PgSearch
+      extend PgSearch
       pg_search_scope :that_sounds_like,
                       :against => :spelling,
                       :using => :dmetaphone
@@ -667,7 +667,7 @@ package](http://www.postgresql.org/docs/current/static/pgtrgm.html) that must
 be installed before this feature can be used.
 
     class Website < ActiveRecord::Base
-      include PgSearch
+      extend PgSearch
       pg_search_scope :kinda_spelled_like,
                       :against => :name,
                       :using => :trigram
@@ -688,7 +688,7 @@ Higher numbers match more strictly, and thus return fewer results. Lower numbers
 match more permissively, letting in more results.
 
     class Vegetable < ActiveRecord::Base
-      include PgSearch
+      extend PgSearch
 
       pg_search_scope :strictly_spelled_like,
                       :against => :name,
@@ -728,7 +728,7 @@ package](http://www.postgresql.org/docs/current/static/unaccent.html) that
 must be installed before this feature can be used.
 
     class SpanishQuestion < ActiveRecord::Base
-      include PgSearch
+      extend PgSearch
       pg_search_scope :gringo_search,
                       :against => :word,
                       :ignoring => :accents

--- a/lib/pg_search.rb
+++ b/lib/pg_search.rb
@@ -5,6 +5,7 @@ require "active_support/core_ext/string/strip"
 require "pg_search/extensions/arel"
 
 module PgSearch
+  autoload :Compatibility, "pg_search/compatibility"
   autoload :Configuration, "pg_search/configuration"
   autoload :Document, "pg_search/document"
   autoload :Features, "pg_search/features"
@@ -15,6 +16,7 @@ module PgSearch
   autoload :VERSION, "pg_search/version"
 
   extend ActiveSupport::Concern
+  include Compatibility::ActiveRecord3 if ActiveRecord::VERSION::MAJOR == 3
 
   mattr_accessor :multisearch_options
   self.multisearch_options = {}
@@ -51,10 +53,6 @@ module PgSearch
       class_attribute :pg_search_multisearchable_options
       self.pg_search_multisearchable_options = options
     end
-  end
-
-  def pg_search_rank
-    read_attribute(:pg_search_rank).to_f
   end
 
   class << self

--- a/lib/pg_search.rb
+++ b/lib/pg_search.rb
@@ -55,6 +55,10 @@ module PgSearch
       mod.send :include, Compatibility::ActiveRecord3
     end
 
+    def included _
+      raise 'extend PgSearch instead of including it'
+    end
+
     def multisearch(*args)
       PgSearch::Document.search(*args)
     end

--- a/lib/pg_search/compatibility.rb
+++ b/lib/pg_search/compatibility.rb
@@ -1,0 +1,9 @@
+module PgSearch
+  module Compatibility
+    module ActiveRecord3
+      def pg_search_rank
+        read_attribute(:pg_search_rank).to_f
+      end
+    end
+  end
+end

--- a/lib/pg_search/document.rb
+++ b/lib/pg_search/document.rb
@@ -2,7 +2,7 @@ require "logger"
 
 module PgSearch
   class Document < ActiveRecord::Base
-    include PgSearch
+    extend PgSearch
     self.table_name = 'pg_search_documents'
     belongs_to :searchable, :polymorphic => true
 

--- a/lib/pg_search/multisearchable.rb
+++ b/lib/pg_search/multisearchable.rb
@@ -1,18 +1,17 @@
-require "active_support/concern"
 require "active_support/core_ext/class/attribute"
 
 module PgSearch
   module Multisearchable
-    extend ActiveSupport::Concern
+    def self.included mod
+      mod.class_eval do
+        has_one :pg_search_document,
+          :as => :searchable,
+          :class_name => "PgSearch::Document",
+          :dependent => :delete
 
-    included do
-      has_one :pg_search_document,
-        :as => :searchable,
-        :class_name => "PgSearch::Document",
-        :dependent => :delete
-
-      after_save :update_pg_search_document,
-        :if => lambda { PgSearch.multisearch_enabled? }
+        after_save :update_pg_search_document,
+          :if => lambda { PgSearch.multisearch_enabled? }
+      end
     end
 
     def update_pg_search_document

--- a/spec/integration/associations_spec.rb
+++ b/spec/integration/associations_spec.rb
@@ -16,7 +16,7 @@ describe PgSearch do
         end
 
         model do
-          include PgSearch
+          extend PgSearch
           belongs_to :another_model, :class_name => 'AssociatedModel'
 
           pg_search_scope :with_another, :associated_against => {:another_model => :title}
@@ -53,7 +53,7 @@ describe PgSearch do
         end
 
         model do
-          include PgSearch
+          extend PgSearch
           belongs_to :another_model, :class_name => 'AssociatedModel'
 
           pg_search_scope :with_associated, :against => :title, :associated_against => {:another_model => :title}
@@ -89,7 +89,7 @@ describe PgSearch do
         end
 
         model do
-          include PgSearch
+          extend PgSearch
           has_many :other_models, :class_name => 'AssociatedModelWithHasMany', :foreign_key => 'ModelWithHasMany_id'
 
           pg_search_scope :with_associated, :against => [:title], :associated_against => {:other_models => :title}
@@ -159,7 +159,7 @@ describe PgSearch do
           end
 
           model do
-            include PgSearch
+            extend PgSearch
             has_many :models_of_first_type, :class_name => 'FirstAssociatedModel', :foreign_key => 'ModelWithManyAssociations_id'
             belongs_to :model_of_second_type, :class_name => 'SecondAssociatedModel'
 
@@ -213,7 +213,7 @@ describe PgSearch do
           end
 
           model do
-            include PgSearch
+            extend PgSearch
             has_many :things, :class_name => 'DoublyAssociatedModel', :foreign_key => 'ModelWithDoubleAssociation_id'
             has_many :thingamabobs, :class_name => 'DoublyAssociatedModel', :foreign_key => 'ModelWithDoubleAssociation_again_id'
 
@@ -267,7 +267,7 @@ describe PgSearch do
         end
 
         model do
-          include PgSearch
+          extend PgSearch
           belongs_to :another_model, :class_name => 'AssociatedModel'
 
           pg_search_scope :with_associated, :associated_against => {:another_model => [:title, :author]}
@@ -321,7 +321,7 @@ describe PgSearch do
         end
 
         model do
-          include PgSearch
+          extend PgSearch
           belongs_to :another_model, :class_name => 'AssociatedModel'
 
           pg_search_scope :with_associated, :associated_against => {:another_model => :number}
@@ -352,7 +352,7 @@ describe PgSearch do
 
         model do
           has_many :children
-          include PgSearch
+          extend PgSearch
           pg_search_scope :search_name, :against => :name
         end
       end
@@ -395,7 +395,7 @@ describe PgSearch do
       end
 
       model do
-        include PgSearch
+        extend PgSearch
         belongs_to :model_with_association
 
         pg_search_scope :search_content, :against => :content
@@ -441,7 +441,7 @@ describe PgSearch do
       end
 
       model do
-        include PgSearch
+        extend PgSearch
         pg_search_scope :search, :against => :title, :using => [:tsearch, :trigram]
       end
     end
@@ -482,7 +482,7 @@ describe PgSearch do
       end
 
       model do
-        include PgSearch
+        extend PgSearch
         pg_search_scope :search, :against => :title, :using => [:tsearch, :trigram]
       end
     end

--- a/spec/integration/pagination_spec.rb
+++ b/spec/integration/pagination_spec.rb
@@ -8,7 +8,7 @@ describe "pagination" do
       end
 
       model do
-        include PgSearch
+        extend PgSearch
         pg_search_scope :search_name, :against => :name
 
         def self.page(page_number)

--- a/spec/integration/pg_search_spec.rb
+++ b/spec/integration/pg_search_spec.rb
@@ -9,7 +9,7 @@ describe "an Active Record model which includes PgSearch" do
     end
 
     model do
-      include PgSearch
+      extend PgSearch
     end
   end
 
@@ -252,7 +252,7 @@ describe "an Active Record model which includes PgSearch" do
           end
 
           model do
-            include PgSearch
+            extend PgSearch
 
             # WARNING: searching timestamps is not something PostgreSQL
             # full-text search is good at. Use at your own risk.
@@ -675,7 +675,7 @@ describe "an Active Record model which includes PgSearch" do
           t.tsvector 'content_tsvector'
         end
 
-        model { include PgSearch }
+        model { extend PgSearch }
       end
 
       let!(:expected) { ModelWithTsvector.create!(:content => 'tiling is grouty') }
@@ -863,7 +863,7 @@ describe "an Active Record model which includes PgSearch" do
         end
 
         model do
-          include PgSearch
+          extend PgSearch
         end
       end
 
@@ -937,7 +937,7 @@ describe "an Active Record model which includes PgSearch" do
           t.string :title
         end
         model do
-          include PgSearch
+          extend PgSearch
           multisearchable :against => :title
         end
       end
@@ -967,7 +967,7 @@ describe "an Active Record model which includes PgSearch" do
           t.string :title
         end
         model do
-          include PgSearch
+          extend PgSearch
           multisearchable :against => :title
         end
       end

--- a/spec/lib/pg_search/document_spec.rb
+++ b/spec/lib/pg_search/document_spec.rb
@@ -6,7 +6,7 @@ describe PgSearch::Document do
   with_model :Searchable do
     table
     model do
-      include PgSearch
+      extend PgSearch
       multisearchable
     end
   end

--- a/spec/lib/pg_search/multisearch/rebuilder_spec.rb
+++ b/spec/lib/pg_search/multisearch/rebuilder_spec.rb
@@ -8,7 +8,7 @@ describe PgSearch::Multisearch::Rebuilder do
       context "and multisearchable is not conditional" do
         with_model :Model do
           model do
-            include PgSearch
+            extend PgSearch
             multisearchable
 
             def rebuild_pg_search_documents
@@ -32,7 +32,7 @@ describe PgSearch::Multisearch::Rebuilder do
               end
 
               model do
-                include PgSearch
+                extend PgSearch
                 multisearchable conditional_key => :active?
 
                 def rebuild_pg_search_documents
@@ -58,7 +58,7 @@ describe PgSearch::Multisearch::Rebuilder do
           end
 
           model do
-            include PgSearch
+            extend PgSearch
             multisearchable :against => :name
           end
         end
@@ -134,7 +134,7 @@ describe PgSearch::Multisearch::Rebuilder do
             end
 
             model do
-              include PgSearch
+              extend PgSearch
               multisearchable :if => :active?
             end
           end
@@ -170,7 +170,7 @@ describe PgSearch::Multisearch::Rebuilder do
             end
 
             model do
-              include PgSearch
+              extend PgSearch
               multisearchable :unless => :inactive?
             end
           end

--- a/spec/lib/pg_search/multisearch_spec.rb
+++ b/spec/lib/pg_search/multisearch_spec.rb
@@ -10,7 +10,7 @@ describe PgSearch::Multisearch do
       t.timestamps
     end
     model do
-      include PgSearch
+      extend PgSearch
     end
   end
 

--- a/spec/lib/pg_search/multisearchable_spec.rb
+++ b/spec/lib/pg_search/multisearchable_spec.rb
@@ -6,7 +6,7 @@ describe PgSearch::Multisearchable do
   describe "a model that is multisearchable" do
     with_model :ModelThatIsMultisearchable do
       model do
-        include PgSearch
+        extend PgSearch
         multisearchable
       end
     end
@@ -104,7 +104,7 @@ describe PgSearch::Multisearchable do
         end
 
         model do
-          include PgSearch
+          extend PgSearch
           multisearchable :if => lambda { |record| record.multisearchable? }
         end
       end
@@ -232,7 +232,7 @@ describe PgSearch::Multisearchable do
         end
 
         model do
-          include PgSearch
+          extend PgSearch
           multisearchable :unless => lambda { |record| record.not_multisearchable? }
         end
       end
@@ -361,7 +361,7 @@ describe PgSearch::Multisearchable do
         end
 
         model do
-          include PgSearch
+          extend PgSearch
           multisearchable :if => :multisearchable?
         end
       end
@@ -493,7 +493,7 @@ describe PgSearch::Multisearchable do
         end
 
         model do
-          include PgSearch
+          extend PgSearch
           multisearchable :unless => :not_multisearchable?
         end
       end

--- a/spec/lib/pg_search_spec.rb
+++ b/spec/lib/pg_search_spec.rb
@@ -1,0 +1,9 @@
+require 'spec_helper'
+
+describe PgSearch do
+  it "raises an error when included" do
+    expect do
+      Module.new { include PgSearch }
+    end.to raise_error 'extend PgSearch instead of including it'
+  end
+end


### PR DESCRIPTION
Quick summary.
- Removes use of `ActiveSupport::Concern` as it’s generally not actually needed (I think someone once quipped: “use of `ActiveSupport::Concern` is concerning” :wink:)
- Changes to extending `PgSearch` instead of including. Raises an error when trying to `include` to inform the user.
- Moves `pg_search_rank` to `PgSearch::Compatibility::ActiveRecord3` and only include if needed to indicate it’s not needed for ActiveRecord 4+. This is the lone instance method on PgSearch objects we add, and @nertzy agrees we may want to rethink adding it by default.

The first two points will make #148 easier as we will no longer have to delay the requiring of `PgSearch::Document` till after we add all methods to `PgSearch` (since `ActiveSupport::Concern` was the real problem causing that need).
