### PR TITLE
allow simultaneously searching on both tsvector & associated columns

### DIFF
--- a/spec/integration/pg_search_spec.rb
+++ b/spec/integration/pg_search_spec.rb
@@ -747,7 +747,7 @@ describe "an Active Record model which includes PgSearch" do
         SQL
 
         ModelWithTsvector.pg_search_scope :search_by_content_with_tsvector,
-          :against => [],
+          :against => :content,
           :using => {
             :tsearch => {
               :tsvector_column => 'content_tsvector',


### PR DESCRIPTION
Progression of #152. (I can't reopen it after @nertzy closed it.)

Thanks for the pushback, made me rethink why I opened this in the first place, which is that I needed to use associations and a tsvector at the same time.
