### PR TITLE
PgSearch::Document searchable_type fix for STI

### DIFF
--- a/lib/pg_search/multisearchable.rb
+++ b/lib/pg_search/multisearchable.rb
@@ -23,7 +23,10 @@ module PgSearch
         unless_conditions.all? { |condition| !condition.to_proc.call(self) }
 
       if should_have_document
-        pg_search_document ? pg_search_document.save : create_pg_search_document
+        unless pg_search_document.present?
+          build_pg_search_document.searchable_type = self.class.name
+        end
+        pg_search_document.save
       else
         pg_search_document.destroy if pg_search_document
       end


### PR DESCRIPTION
searchable_type contained root class for STI subclass
This commit fixes this bug, searchable_type now contains subclass type

See @elbouillon comments https://github.com/Casecommons/pg_search/issues/59
