### PR TITLE
Add support for non-standard primary keys

### DIFF
--- a/lib/pg_search/multisearch/rebuilder.rb
+++ b/lib/pg_search/multisearch/rebuilder.rb
@@ -28,20 +28,26 @@ module PgSearch
         model.connection
       end
 
-      REBUILD_SQL_TEMPLATE = <<-SQL.strip_heredoc
-        INSERT INTO :documents_table (searchable_type, searchable_id, content, created_at, updated_at)
-          SELECT :model_name AS searchable_type,
-                 :model_table.id AS searchable_id,
-                 (
-                   :content_expressions
-                 ) AS content,
-                 :current_time AS created_at,
-                 :current_time AS updated_at
-          FROM :model_table
-      SQL
+      def primary_key
+        model.primary_key
+      end
+
+      def rebuild_sql_template
+         <<-SQL.strip_heredoc
+          INSERT INTO :documents_table (searchable_type, searchable_id, content, created_at, updated_at)
+            SELECT :model_name AS searchable_type,
+                   :model_table.#{primary_key} AS searchable_id,
+                   (
+                     :content_expressions
+                   ) AS content,
+                   :current_time AS created_at,
+                   :current_time AS updated_at
+            FROM :model_table
+        SQL
+      end
 
       def rebuild_sql
-        replacements.inject(REBUILD_SQL_TEMPLATE) do |sql, key|
+        replacements.inject(rebuild_sql_template) do |sql, key|
           sql.gsub ":#{key}", send(key)
         end
       end

--- a/spec/lib/pg_search/multisearch/rebuilder_spec.rb
+++ b/spec/lib/pg_search/multisearch/rebuilder_spec.rb
@@ -103,7 +103,7 @@ describe PgSearch::Multisearch::Rebuilder do
           expected_sql = <<-SQL.strip_heredoc
             INSERT INTO "pg_search_documents" (searchable_type, searchable_id, content, created_at, updated_at)
               SELECT 'Model' AS searchable_type,
-                     #{Model.quoted_table_name}.id AS searchable_id,
+                     #{Model.quoted_table_name}.#{Model.primary_key} AS searchable_id,
                      (
                        coalesce(#{Model.quoted_table_name}.name::text, '')
                      ) AS content,


### PR DESCRIPTION
Use the `ActiveRecord` `primary_key` method instead of hardcoding `id`.
