### PR TITLE
Multiple tsvector support in tsearch

### DIFF
--- a/lib/pg_search/features/tsearch.rb
+++ b/lib/pg_search/features/tsearch.rb
@@ -76,8 +76,17 @@ module PgSearch
         end
 
         if options[:tsvector_column]
-          column_name = connection.quote_column_name(options[:tsvector_column])
-          tsdocument_terms << "#{quoted_table_name}.#{column_name}"
+          if options[:tsvector_column].is_a?(Array)
+            tsvector_columns = options[:tsvector_column]
+          else
+            tsvector_columns = [options[:tsvector_column]]
+          end
+
+          tsdocument_terms << tsvector_columns.map do |tsvector_column|
+            column_name = connection.quote_column_name(tsvector_column)
+
+            "#{quoted_table_name}.#{column_name}"
+          end
         end
 
         tsdocument_terms.join(' || ')

--- a/spec/integration/pg_search_spec.rb
+++ b/spec/integration/pg_search_spec.rb
@@ -735,6 +735,30 @@ describe "an Active Record model which includes PgSearch" do
       end
     end
 
+    context 'using multiple tsvector columns' do
+      with_model :ModelWithTsvector do
+        model do
+          include PgSearch
+
+          pg_search_scope :search_by_multiple_tsvector_columns,
+            :against => ['content', 'message'],
+            :using => {
+              :tsearch => {
+                :tsvector_column => ['content_tsvector', 'message_tsvector'],
+                :dictionary => 'english'
+              }
+            }
+        end
+      end
+
+      it 'concats tsvector columns' do
+        expected = "#{ModelWithTsvector.quoted_table_name}.\"content_tsvector\" || "\
+                   "#{ModelWithTsvector.quoted_table_name}.\"message_tsvector\""
+
+        expect(ModelWithTsvector.search_by_multiple_tsvector_columns("something").to_sql).to include(expected)
+      end
+    end
+
     context "using a tsvector column with" do
       with_model :ModelWithTsvector do
         table do |t|


### PR DESCRIPTION
Use case is when developers want to do a search query using multiple tsvector columns. Shoot at it!
