### PR TITLE
adding a :query prefix option

### DIFF
--- a/lib/pg_search/features/tsearch.rb
+++ b/lib/pg_search/features/tsearch.rb
@@ -40,7 +40,7 @@ module PgSearch
           Compatibility.build_quoted("' "),
           term_sql,
           Compatibility.build_quoted(" '"),
-          (Compatibility.build_quoted(":*") if (options[:prefix] == true or (options[:prefix] == :query and !term.index('*').nil?) ))
+          (Compatibility.build_quoted(":*") if (options[:prefix] == true or (options[:prefix] == :query and !unsanitized_term.index('*').nil?) ))
         ].compact
 
         tsquery_sql = terms.inject do |memo, term|


### PR DESCRIPTION
This feature adds the ability to evaluate if a prefix should be added on a per term basis when the user specifies \* in the query term.  Useful when searching for company names which do not stem naturally and when we only want to prefix one of the term instead of every term.

Specifying :prefix => :query in the pg search option will turn on this feature.

For instance, if I have a customer name of "Directbuy of Cincinatti" it can be found using "Directbuy Cin*"  and target the prefix search. 
