### PR TITLE
Add :only option for limiting trigram search fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -766,6 +766,39 @@ Vegetable.roughly_spelled_like("collyflower") # => [cauliflower]
 Vegetable.strictly_spelled_like("collyflower") # => []
 ```
 
+### Limiting Fields When Combining Features 
+
+Sometimes when doing queries combining different features you 
+might want to searching against only some of the fields with certain features.
+For example perhaps you want to only do a trigram search against the shorter fields
+so that you don't need to reduce the threshold excessively. You can specify 
+which fields using the 'only' option:
+
+```ruby
+class Image < ActiveRecord::Base
+  include PgSearch
+
+  pg_search_scope :combined_search,
+                  :against => [:file_name, :short_description, :long_description]
+                  :using => {
+                    :tsearch => { :dictionary  => 'english' },
+                    :trigram => {
+                      :only => [:file_name, :short_description]
+                    }
+                  }
+
+end
+```
+
+Now you can succesfully retrieve an Image with a file_name: 'image_foo.jpg' 
+and long_description: 'This description is so long that it would make a trigram search
+fail any reasonable threshold limit' with:
+
+```ruby
+Image.combined_search('reasonable') # found with tsearch
+Image.combined_search('foo') # found with trigram
+```
+
 ### Ignoring accent marks (PostgreSQL 9.0 and newer only)
 
 Most of the time you will want to ignore accent marks when searching. This

--- a/lib/pg_search/configuration/column.rb
+++ b/lib/pg_search/configuration/column.rb
@@ -3,9 +3,10 @@ require 'digest'
 module PgSearch
   class Configuration
     class Column
-      attr_reader :weight
+      attr_reader :weight, :name
 
       def initialize(column_name, weight, model)
+        @name = column_name.to_s
         @column_name = column_name.to_s
         @weight = weight
         @model = model

--- a/lib/pg_search/features/feature.rb
+++ b/lib/pg_search/features/feature.rb
@@ -8,7 +8,13 @@ module PgSearch
       def initialize(query, options, columns, model, normalizer)
         @query = query
         @options = options || {}
-        @columns = columns
+        if @options[:only]
+          @columns = columns.select do
+            |c| [options[:only]].flatten.map(&:to_s).include? c.name 
+          end
+        else
+          @columns = columns
+        end
         @model = model
         @normalizer = normalizer
       end

--- a/lib/pg_search/features/trigram.rb
+++ b/lib/pg_search/features/trigram.rb
@@ -1,6 +1,7 @@
 module PgSearch
   module Features
     class Trigram < Feature
+
       def conditions
         if options[:threshold]
           Arel::Nodes::Grouping.new(

--- a/spec/lib/pg_search/features/trigram_spec.rb
+++ b/spec/lib/pg_search/features/trigram_spec.rb
@@ -50,6 +50,27 @@ describe PgSearch::Features::Trigram do
       end
     end
 
+    context 'only certain columns are selected' do
+      context 'one column' do
+        let(:options) { { only: :name } }
+
+        it 'only searches against the select column' do
+          options = { only: :name }
+          coalesced_column = "coalesce(#{Model.quoted_table_name}.\"name\"::text, '')"
+          expect(feature.conditions.to_sql).to eq("((#{coalesced_column}) % '#{query}')")
+        end
+
+      end
+      context 'multiple columns' do
+        let(:options) { { only: [:name, :content] } }
+
+        it 'concatenates when multiples columns are selected' do
+          options = { only: [:name, :content] }
+          expect(feature.conditions.to_sql).to eq("((#{coalesced_columns}) % '#{query}')")
+        end
+      end
+    end
+
   end
 
   describe '#rank' do


### PR DESCRIPTION
Addresses:
https://groups.google.com/forum/#!topic/casecommons-dev/yOojbQoVdWE

I wasn't sure how active things were on the mailing list these days so I just went ahead and implemented a pull request. Please offer suggestions if this is not acceptable as is. 
