### PR TITLE
Gemspec includes, installs binstubs

### DIFF
--- a/pg_search.gemspec
+++ b/pg_search.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
 
   s.files         = `git ls-files`.split("\n")
   s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")
-  s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
+  # s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = ["lib"]
 
   s.add_dependency 'activerecord', '>=3.1'


### PR DESCRIPTION
The gemspec currently includes the entire contents of the `bin` directory, which results in pg_search 0.7.7 attempting to install its rspec and guard binstubs as global executables.

Since pg_search does not currently provide any executables, this pull request simply comments out the `s.executables` directive.
