### PR TITLE
Return highlighted excerpt of result

### DIFF
--- a/README.md
+++ b/README.md
@@ -737,7 +737,7 @@ first_match = Person.search("Alberta").first
 first_match.pg_highlight # => "Born in rural <b>Alberta</b>, where the buffalo roam."
 ```
 
-By default, it will add the delimiters `<b>` and `</b>` around the matched text. You can customize these delimiters with the `:start_sel` and `stop_sel` options.
+By default, it will add the delimiters `<b>` and `</b>` around the matched text. You can customize these delimiters and the number of fragments returned with the `:start_sel`, `stop_sel`, and `max_fragments` options.
 
 ```ruby
 class Person < ActiveRecord::Base
@@ -748,7 +748,8 @@ class Person < ActiveRecord::Base
                     :tsearch => {
                       :highlight => {
                         :start_sel => "*BEGIN*",
-                        :stop_sel => "*END*"
+                        :stop_sel => "*END*",
+                        :max_fragments => 1
                       }
                     }
                   }

--- a/README.md
+++ b/README.md
@@ -717,6 +717,49 @@ one_close = Person.create!(:name => 'leigh heinz')
 Person.search('ash hines') # => [exact, one_exact_one_close, one_exact]
 ```
 
+##### :highlight (PostgreSQL 9.0 and newer only)
+
+Setting this attribute to true will return an excerpt of the matching text for the search term in a `pg_highlight` attribute.
+
+```ruby
+class Person < ActiveRecord::Base
+  include PgSearch
+  pg_search_scope :search,
+                  :against => :bio,
+                  :using => {
+                    :tsearch => {:highlight => true}
+                  }
+end
+
+Person.create!(:bio => "Born in rural Alberta, where the buffalo roam.")
+
+first_match = Person.search("Alberta").first
+first_match.pg_highlight # => "Born in rural <b>Alberta</b>, where the buffalo roam."
+```
+
+By default, it will add the delimiters `<b>` and `</b>` around the matched text. You can customize these delimiters with the `:start_sel` and `stop_sel` options.
+
+```ruby
+class Person < ActiveRecord::Base
+  include PgSearch
+  pg_search_scope :search,
+                  :against => :bio,
+                  :using => {
+                    :tsearch => {
+                      :highlight => {
+                        :start_sel => "*BEGIN*",
+                        :stop_sel => "*END*"
+                      }
+                    }
+                  }
+end
+
+Person.create!(:bio => "Born in rural Alberta, where the buffalo roam.")
+
+first_match = Person.search("Alberta").first
+first_match.pg_highlight # => "Born in rural *BEGIN*Alberta*END*, where the buffalo roam."
+```
+
 #### :dmetaphone (Double Metaphone soundalike search)
 
 [Double Metaphone](http://en.wikipedia.org/wiki/Double_Metaphone) is an

--- a/lib/pg_search/features/tsearch.rb
+++ b/lib/pg_search/features/tsearch.rb
@@ -116,10 +116,6 @@ module PgSearch
       end
 
       def ts_headline
-        document = columns_to_use.map do |column|
-          Arel.sql(normalize(column.to_sql))
-        end.join(' || ')
-
         "ts_headline((#{document}), (#{tsquery}), '#{ts_headline_options}')"
       end
 

--- a/lib/pg_search/features/tsearch.rb
+++ b/lib/pg_search/features/tsearch.rb
@@ -14,6 +14,12 @@ module PgSearch
             Sorry, {:using => {:tsearch => {:prefix => true}}} only works in PostgreSQL 8.4 and above.")
           MESSAGE
         end
+
+        if options[:highlight] && model.connection.send(:postgresql_version) < 90000
+          raise PgSearch::NotSupportedForPostgresqlVersion.new(<<-MESSAGE.strip_heredoc)
+            Sorry, {:using => {:tsearch => {:highlight => true}}} only works in PostgreSQL 9.0 and above.")
+          MESSAGE
+        end
       end
 
       def conditions

--- a/lib/pg_search/features/tsearch.rb
+++ b/lib/pg_search/features/tsearch.rb
@@ -9,13 +9,15 @@ module PgSearch
       def initialize(*args)
         super
 
-        if options[:prefix] && model.connection.send(:postgresql_version) < 80400
+        pg_version = model.connection.send(:postgresql_version)
+
+        if options[:prefix] && pg_version < 80400
           raise PgSearch::NotSupportedForPostgresqlVersion.new(<<-MESSAGE.strip_heredoc)
             Sorry, {:using => {:tsearch => {:prefix => true}}} only works in PostgreSQL 8.4 and above.")
           MESSAGE
         end
 
-        if options[:highlight] && model.connection.send(:postgresql_version) < 90000
+        if options[:highlight] && pg_version < 90000
           raise PgSearch::NotSupportedForPostgresqlVersion.new(<<-MESSAGE.strip_heredoc)
             Sorry, {:using => {:tsearch => {:highlight => true}}} only works in PostgreSQL 9.0 and above.")
           MESSAGE

--- a/lib/pg_search/features/tsearch.rb
+++ b/lib/pg_search/features/tsearch.rb
@@ -1,3 +1,5 @@
+# rubocop:disable Metrics/ClassLength
+
 require "pg_search/compatibility"
 require "active_support/core_ext/module/delegation"
 

--- a/lib/pg_search/features/tsearch.rb
+++ b/lib/pg_search/features/tsearch.rb
@@ -154,6 +154,7 @@ module PgSearch
         headline_options = {}
         headline_options["StartSel"] = options[:highlight][:start_sel]
         headline_options["StopSel"] = options[:highlight][:stop_sel]
+        headline_options["MaxFragments"] = options[:highlight][:max_fragments]
 
         headline_options.map do |key, value|
           "#{key} = #{value}" if value

--- a/spec/integration/pg_search_spec.rb
+++ b/spec/integration/pg_search_spec.rb
@@ -416,6 +416,52 @@ describe "an Active Record model which includes PgSearch" do
         end
       end
 
+      describe "highlighting" do
+        before do
+          ["Strip Down", "Down", "Down and Out", "Won't Let You Down"].each do |name|
+            ModelWithPgSearch.create! :content => name
+          end
+        end
+
+        context "with highlight turned on" do
+          before do
+            ModelWithPgSearch.pg_search_scope :search_content,
+              :against => :content,
+              :using => {
+                :tsearch => {:highlight => true}
+              }
+          end
+
+          it "adds a #pg_highlight method to each returned model record" do
+            result = ModelWithPgSearch.search_content("Strip Down").first
+
+            expect(result.pg_highlight).to be_a(String)
+          end
+
+          it "returns excerpts of text where search match occurred" do
+            result = ModelWithPgSearch.search_content("Let").first
+
+            expect(result.pg_highlight).to eq("Won't <b>Let</b> You Down")
+          end
+        end
+
+        context "with highlight turned off" do
+          before do
+            ModelWithPgSearch.pg_search_scope :search_content,
+              :against => :content,
+              :using => {
+                :tsearch => {:highlight => false}
+              }
+          end
+
+          it "does not add a #pg_highlight method to each returned model record" do
+            result = ModelWithPgSearch.search_content("Strip Down").first
+
+            expect(result).to_not respond_to(:pg_highlight)
+          end
+        end
+      end
+
       describe "ranking" do
         before do
           ["Strip Down", "Down", "Down and Out", "Won't Let You Down"].each do |name|
@@ -717,7 +763,8 @@ describe "an Active Record model which includes PgSearch" do
         it "should pass the custom configuration down to the specified feature" do
           stub_feature = double(
             :conditions => Arel::Nodes::Grouping.new(Arel.sql("1 = 1")),
-            :rank => Arel::Nodes::Grouping.new(Arel.sql("1.0"))
+            :rank => Arel::Nodes::Grouping.new(Arel.sql("1.0")),
+            :highlight => nil
           )
 
           expect(PgSearch::Features::TSearch).to receive(:new).with(anything, @tsearch_config, anything, anything, anything).at_least(:once).and_return(stub_feature)

--- a/spec/lib/pg_search/features/tsearch_spec.rb
+++ b/spec/lib/pg_search/features/tsearch_spec.rb
@@ -149,40 +149,42 @@ describe PgSearch::Features::TSearch do
           described_class.new(query, options, columns, mock_model, normalizer)
         }.to raise_error(PgSearch::NotSupportedForPostgresqlVersion)
       end
+
+      it "returns an expression using the ts_headline() function" do
+        query = "query"
+        columns = [
+          PgSearch::Configuration::Column.new(:name, nil, Model),
+          PgSearch::Configuration::Column.new(:content, nil, Model),
+        ]
+        options = { highlight: true }
+        config = double(:config, :ignore => [])
+        normalizer = PgSearch::Normalizer.new(config)
+
+        feature = described_class.new(query, options, columns, Model, normalizer)
+
+        expect(feature.highlight.to_sql).to eq(
+          %Q{(ts_headline((coalesce(#{Model.quoted_table_name}."name"::text, '') || coalesce(#{Model.quoted_table_name}."content"::text, '')), (to_tsquery('simple', ''' ' || 'query' || ' ''')), ''))}
+        )
+      end
     end
 
-    it "returns an expression using the ts_headline() function" do
-      query = "query"
-      columns = [
-        PgSearch::Configuration::Column.new(:name, nil, Model),
-        PgSearch::Configuration::Column.new(:content, nil, Model),
-      ]
-      options = { highlight: true }
-      config = double(:config, :ignore => [])
-      normalizer = PgSearch::Normalizer.new(config)
+    context "when options[:highlight] includes :start_sel and :stop_sel" do
+      it "allows for custom query delimiters" do
+        query = "query"
+        columns = [
+          PgSearch::Configuration::Column.new(:name, nil, Model),
+          PgSearch::Configuration::Column.new(:content, nil, Model),
+        ]
+        options = { highlight: { start_sel: "<match>", stop_sel: "</match>" } }
+        config = double(:config, :ignore => [])
+        normalizer = PgSearch::Normalizer.new(config)
 
-      feature = described_class.new(query, options, columns, Model, normalizer)
+        feature = described_class.new(query, options, columns, Model, normalizer)
 
-      expect(feature.highlight.to_sql).to eq(
-        %Q{(ts_headline((coalesce(#{Model.quoted_table_name}."name"::text, '') || coalesce(#{Model.quoted_table_name}."content"::text, '')), (to_tsquery('simple', ''' ' || 'query' || ' ''')), ''))}
-      )
-    end
-
-    it "allows for custom query delimiters" do
-      query = "query"
-      columns = [
-        PgSearch::Configuration::Column.new(:name, nil, Model),
-        PgSearch::Configuration::Column.new(:content, nil, Model),
-      ]
-      options = { highlight: { start_sel: "<match>", stop_sel: "</match>" } }
-      config = double(:config, :ignore => [])
-      normalizer = PgSearch::Normalizer.new(config)
-
-      feature = described_class.new(query, options, columns, Model, normalizer)
-
-      expect(feature.highlight.to_sql).to eq(
-        %Q{(ts_headline((coalesce(#{Model.quoted_table_name}."name"::text, '') || coalesce(#{Model.quoted_table_name}."content"::text, '')), (to_tsquery('simple', ''' ' || 'query' || ' ''')), 'StartSel = <match>, StopSel = </match>'))}
-      )
+        expect(feature.highlight.to_sql).to eq(
+          %Q{(ts_headline((coalesce(#{Model.quoted_table_name}."name"::text, '') || coalesce(#{Model.quoted_table_name}."content"::text, '')), (to_tsquery('simple', ''' ' || 'query' || ' ''')), 'StartSel = <match>, StopSel = </match>'))}
+        )
+      end
     end
   end
 end

--- a/spec/lib/pg_search/features/tsearch_spec.rb
+++ b/spec/lib/pg_search/features/tsearch_spec.rb
@@ -122,4 +122,47 @@ describe PgSearch::Features::TSearch do
       end
     end
   end
+
+  describe "#highlight" do
+    with_model :Model do
+      table do |t|
+        t.string :name
+        t.text :content
+      end
+    end
+
+    it "returns an expression using the ts_headline() function" do
+      query = "query"
+      columns = [
+        PgSearch::Configuration::Column.new(:name, nil, Model),
+        PgSearch::Configuration::Column.new(:content, nil, Model),
+      ]
+      options = { highlight: true }
+      config = double(:config, :ignore => [])
+      normalizer = PgSearch::Normalizer.new(config)
+
+      feature = described_class.new(query, options, columns, Model, normalizer)
+
+      expect(feature.highlight.to_sql).to eq(
+        %Q{(ts_headline((coalesce(#{Model.quoted_table_name}."name"::text, '') || coalesce(#{Model.quoted_table_name}."content"::text, '')), (to_tsquery('simple', ''' ' || 'query' || ' ''')), ''))}
+      )
+    end
+
+    it "allows for custom query delimiters" do
+      query = "query"
+      columns = [
+        PgSearch::Configuration::Column.new(:name, nil, Model),
+        PgSearch::Configuration::Column.new(:content, nil, Model),
+      ]
+      options = { highlight: { start_sel: "<match>", stop_sel: "</match>" } }
+      config = double(:config, :ignore => [])
+      normalizer = PgSearch::Normalizer.new(config)
+
+      feature = described_class.new(query, options, columns, Model, normalizer)
+
+      expect(feature.highlight.to_sql).to eq(
+        %Q{(ts_headline((coalesce(#{Model.quoted_table_name}."name"::text, '') || coalesce(#{Model.quoted_table_name}."content"::text, '')), (to_tsquery('simple', ''' ' || 'query' || ' ''')), 'StartSel = <match>, StopSel = </match>'))}
+      )
+    end
+  end
 end

--- a/spec/lib/pg_search/features/tsearch_spec.rb
+++ b/spec/lib/pg_search/features/tsearch_spec.rb
@@ -131,6 +131,26 @@ describe PgSearch::Features::TSearch do
       end
     end
 
+    context "when options[:highlight] is set" do
+      it "throws an error for PostgreSQL versions < 9.0" do
+        query = "query"
+        columns = [
+          PgSearch::Configuration::Column.new(:name, nil, Model),
+          PgSearch::Configuration::Column.new(:content, nil, Model),
+        ]
+        options = { highlight: true }
+        config = double(:config, :ignore => [])
+        normalizer = PgSearch::Normalizer.new(config)
+
+        connection = double(:connection, :postgresql_version => 80400)
+        mock_model = double(:model, :connection => connection)
+
+        expect {
+          described_class.new(query, options, columns, mock_model, normalizer)
+        }.to raise_error(PgSearch::NotSupportedForPostgresqlVersion)
+      end
+    end
+
     it "returns an expression using the ts_headline() function" do
       query = "query"
       columns = [

--- a/spec/lib/pg_search/features/tsearch_spec.rb
+++ b/spec/lib/pg_search/features/tsearch_spec.rb
@@ -163,7 +163,7 @@ describe PgSearch::Features::TSearch do
         feature = described_class.new(query, options, columns, Model, normalizer)
 
         expect(feature.highlight.to_sql).to eq(
-          %Q{(ts_headline((coalesce(#{Model.quoted_table_name}."name"::text, '') || coalesce(#{Model.quoted_table_name}."content"::text, '')), (to_tsquery('simple', ''' ' || 'query' || ' ''')), ''))}
+          %Q{(ts_headline((coalesce(#{Model.quoted_table_name}."name"::text, '') || ' ' || coalesce(#{Model.quoted_table_name}."content"::text, '')), (to_tsquery('simple', ''' ' || 'query' || ' ''')), ''))}
         )
       end
     end
@@ -182,7 +182,7 @@ describe PgSearch::Features::TSearch do
         feature = described_class.new(query, options, columns, Model, normalizer)
 
         expect(feature.highlight.to_sql).to eq(
-          %Q{(ts_headline((coalesce(#{Model.quoted_table_name}."name"::text, '') || coalesce(#{Model.quoted_table_name}."content"::text, '')), (to_tsquery('simple', ''' ' || 'query' || ' ''')), 'StartSel = <match>, StopSel = </match>'))}
+          %Q{(ts_headline((coalesce(#{Model.quoted_table_name}."name"::text, '') || ' ' || coalesce(#{Model.quoted_table_name}."content"::text, '')), (to_tsquery('simple', ''' ' || 'query' || ' ''')), 'StartSel = <match>, StopSel = </match>'))}
         )
       end
     end

--- a/spec/lib/pg_search/features/tsearch_spec.rb
+++ b/spec/lib/pg_search/features/tsearch_spec.rb
@@ -185,6 +185,25 @@ describe PgSearch::Features::TSearch do
           %Q{(ts_headline((coalesce(#{Model.quoted_table_name}."name"::text, '') || ' ' || coalesce(#{Model.quoted_table_name}."content"::text, '')), (to_tsquery('simple', ''' ' || 'query' || ' ''')), 'StartSel = <match>, StopSel = </match>'))}
         )
       end
+
+      it "allows a maximum number of fragments" do
+        query = "query"
+        columns = [
+          PgSearch::Configuration::Column.new(:name, nil, Model),
+          PgSearch::Configuration::Column.new(:content, nil, Model),
+        ]
+        options = { highlight: { start_sel: "<match>",
+                                 stop_sel: "</match>",
+                                 max_fragments: 2 } }
+        config = double(:config, :ignore => [])
+        normalizer = PgSearch::Normalizer.new(config)
+
+        feature = described_class.new(query, options, columns, Model, normalizer)
+
+        expect(feature.highlight.to_sql).to eq(
+          %Q{(ts_headline((coalesce(#{Model.quoted_table_name}."name"::text, '') || ' ' || coalesce(#{Model.quoted_table_name}."content"::text, '')), (to_tsquery('simple', ''' ' || 'query' || ' ''')), 'StartSel = <match>, StopSel = </match>, MaxFragments = 2'))}
+        )
+      end
     end
   end
 end


### PR DESCRIPTION
Addresses issue #100.

If configuration is set to

```ruby
:using => {
  :tsearch => { :highlight => true }
}
```

then queries will return records with an additional `pg_highlight` attribute.

Currently uses the defaults set by the Postgres function ts_headline, as specified here: http://www.postgresql.org/docs/current/static/textsearch-controls.html#TEXTSEARCH-HEADLINE

Also supports custom delimiters

```ruby
:using => {
  :tsearch => { 
    :highlight => { 
      :start_sel => "begin", 
      :stop_sel => "end" 
    }
  }
}
```

will override the default `<b>` and `</b>` query delimiters in the highlighted results.

NOTE: the pg function used (`ts_headline()`) is _not_ supported on pg versions < 9.0. I know that the gem is intended to support 8.0 and above, but this seemed like a useful enough feature get started. Any way to work around?