### PR TITLE
Assert valid options for features

### DIFF
--- a/lib/pg_search/features/feature.rb
+++ b/lib/pg_search/features/feature.rb
@@ -1,13 +1,18 @@
 require "active_support/core_ext/module/delegation"
+require "active_support/core_ext/hash/keys"
 
 module PgSearch
   module Features
     class Feature
+      def self.valid_options
+        [:only, :sort_only]
+      end
+
       delegate :connection, :quoted_table_name, :to => :'@model'
 
       def initialize(query, options, all_columns, model, normalizer)
         @query = query
-        @options = options || {}
+        @options = (options || {}).assert_valid_keys(self.class.valid_options)
         @all_columns = all_columns
         @model = model
         @normalizer = normalizer

--- a/lib/pg_search/features/trigram.rb
+++ b/lib/pg_search/features/trigram.rb
@@ -1,6 +1,9 @@
 module PgSearch
   module Features
     class Trigram < Feature
+      def self.valid_options
+        super + [:threshold]
+      end
 
       def conditions
         if options[:threshold]

--- a/lib/pg_search/features/tsearch.rb
+++ b/lib/pg_search/features/tsearch.rb
@@ -4,6 +4,10 @@ require "active_support/core_ext/module/delegation"
 module PgSearch
   module Features
     class TSearch < Feature
+      def self.valid_options
+        super + [:dictionary, :prefix, :negation, :any_word, :normalization, :tsvector_column]
+      end
+
       def initialize(*args)
         super
 


### PR DESCRIPTION
I thought it would be nice to assert valid options for features, so that people know when they've made a typo. For example, since English is not my native language, I accidentally gave `:treshold` instead of `:threshold` to the Trigram feature. So it took me a while to figure out what was wrong.

I didn't write tests, because I didn't really find it a feature that would need to be tested (nothing will brake if it stops working).

Lastly, I really want to thank you for this awesome gem. It's really a perfect wrapper for full-text search; while there are great defaults, it's also *very* configurable. It's really easy now to use PostgeSQL for full-text search.