### PR TITLE
Fix test hierarchy, show Multisearch.rebuild(child) STI bug

### DIFF
--- a/spec/integration/pg_search_spec.rb
+++ b/spec/integration/pg_search_spec.rb
@@ -1162,8 +1162,12 @@ describe "an Active Record model which includes PgSearch" do
           include PgSearch
           multisearchable :against => :content
         end
+        another_searchable_subclass_model = Class.new(SuperclassModel) do
+          include PgSearch
+          multisearchable :against => :content
+        end
         stub_const("SearchableSubclassModel", searchable_subclass_model)
-        stub_const("AnotherSearchableSubclassModel", searchable_subclass_model)
+        stub_const("AnotherSearchableSubclassModel", another_searchable_subclass_model)
         stub_const("NonSearchableSubclassModel", Class.new(SuperclassModel))
       end
 


### PR DESCRIPTION
If I have an STI hierarchy where Cat and Dog inherit from Animal, then

    PgSearch::Multisearch.rebuild(Cat)

Destroys ALL Animal records, not just cats.

Luckily, you were testing for this.  Unluckily, the class hierarchy in the test wasn't set up correctly, hiding the failure.  This patch fixes the test so the failure becomes apparent.

I'm not quite sure what the best way to fix this is...  Maybe storing the child's type in the pg_search_documents table?  Maybe just raising an error if you try to rebuild STI children without passing clean_up=false?

Here's the expected error, showing that `PgSearch::Multisearch.rebuild(SearchableSubclassModel)` deleted AnotherSearchableSubclassModel's document:

     Failure/Error: expect(PgSearch::Document.count).to be 2
       
       expected #<Fixnum:5> => 2
            got #<Fixnum:3> => 1
       
     # ./spec/integration/pg_search_spec.rb:1237:in `block (4 levels) in <top (required)>'
