### PR TITLE
Record subclass name in pg_search_documents.

### DIFF
--- a/lib/pg_search/migration/templates/create_pg_search_documents.rb.erb
+++ b/lib/pg_search/migration/templates/create_pg_search_documents.rb.erb
@@ -4,6 +4,7 @@ class CreatePgSearchDocuments < ActiveRecord::Migration
       create_table :pg_search_documents do |t|
         t.text :content
         t.belongs_to :searchable, :polymorphic => true
+        t.string :searchable_subclass_type
         t.timestamps null: false
       end
     end

--- a/lib/pg_search/multisearch.rb
+++ b/lib/pg_search/multisearch.rb
@@ -6,7 +6,7 @@ module PgSearch
     class << self
       def rebuild(model, clean_up=true)
         model.transaction do
-          PgSearch::Document.where(:searchable_type => model.base_class.name).delete_all if clean_up
+          PgSearch::Document.where(:searchable_subclass_type => model.name).delete_all if clean_up
           Rebuilder.new(model).rebuild
         end
       end

--- a/lib/pg_search/multisearch/rebuilder.rb
+++ b/lib/pg_search/multisearch/rebuilder.rb
@@ -34,9 +34,10 @@ module PgSearch
 
       def rebuild_sql_template
          <<-SQL.strip_heredoc
-          INSERT INTO :documents_table (searchable_type, searchable_id, content, created_at, updated_at)
+          INSERT INTO :documents_table (searchable_type, searchable_id, searchable_subclass_type, content, created_at, updated_at)
             SELECT :base_model_name AS searchable_type,
                    :model_table.#{primary_key} AS searchable_id,
+                   :model_name AS searchable_subclass_type,
                    (
                      :content_expressions
                    ) AS content,

--- a/lib/pg_search/multisearchable.rb
+++ b/lib/pg_search/multisearchable.rb
@@ -23,7 +23,7 @@ module PgSearch
         unless_conditions.all? { |condition| !condition.to_proc.call(self) }
 
       if should_have_document
-        pg_search_document ? pg_search_document.save : create_pg_search_document
+        pg_search_document ? pg_search_document.save : create_pg_search_document(:searchable_subclass_type => self.class.name)
       else
         pg_search_document.destroy if pg_search_document
       end

--- a/spec/integration/pg_search_spec.rb
+++ b/spec/integration/pg_search_spec.rb
@@ -1162,8 +1162,12 @@ describe "an Active Record model which includes PgSearch" do
           include PgSearch
           multisearchable :against => :content
         end
+        another_searchable_subclass_model = Class.new(SuperclassModel) do
+          include PgSearch
+          multisearchable :against => :content
+        end
         stub_const("SearchableSubclassModel", searchable_subclass_model)
-        stub_const("AnotherSearchableSubclassModel", searchable_subclass_model)
+        stub_const("AnotherSearchableSubclassModel", another_searchable_subclass_model)
         stub_const("NonSearchableSubclassModel", Class.new(SuperclassModel))
       end
 

--- a/spec/lib/pg_search/multisearch/rebuilder_spec.rb
+++ b/spec/lib/pg_search/multisearch/rebuilder_spec.rb
@@ -100,9 +100,10 @@ describe PgSearch::Multisearch::Rebuilder do
             end
 
           expected_sql = <<-SQL.strip_heredoc
-            INSERT INTO "pg_search_documents" (searchable_type, searchable_id, content, created_at, updated_at)
+            INSERT INTO "pg_search_documents" (searchable_type, searchable_id, searchable_subclass_type, content, created_at, updated_at)
               SELECT 'Model' AS searchable_type,
                      #{Model.quoted_table_name}.#{Model.primary_key} AS searchable_id,
+                     'Model' AS searchable_subclass_type,
                      (
                        coalesce(#{Model.quoted_table_name}.name::text, '')
                      ) AS content,
@@ -156,9 +157,10 @@ describe PgSearch::Multisearch::Rebuilder do
               end
 
             expected_sql = <<-SQL.strip_heredoc
-              INSERT INTO "pg_search_documents" (searchable_type, searchable_id, content, created_at, updated_at)
+              INSERT INTO "pg_search_documents" (searchable_type, searchable_id, searchable_subclass_type, content, created_at, updated_at)
                 SELECT 'ModelWithNonStandardPrimaryKey' AS searchable_type,
                        #{ModelWithNonStandardPrimaryKey.quoted_table_name}.non_standard_primary_key AS searchable_id,
+                       'ModelWithNonStandardPrimaryKey' AS searchable_subclass_type,
                        (
                          coalesce(#{ModelWithNonStandardPrimaryKey.quoted_table_name}.name::text, '')
                        ) AS content,

--- a/spec/lib/pg_search/multisearch_spec.rb
+++ b/spec/lib/pg_search/multisearch_spec.rb
@@ -33,13 +33,13 @@ describe PgSearch::Multisearch do
       before do
         connection.execute <<-SQL.strip_heredoc
           INSERT INTO pg_search_documents
-            (searchable_type, searchable_id, content, created_at, updated_at)
+            (searchable_type, searchable_subclass_type, searchable_id, content, created_at, updated_at)
             VALUES
-            ('#{model.name}', 123, 'foo', now(), now());
+            ('#{model.name}', '#{model.name}', 123, 'foo', now(), now());
           INSERT INTO pg_search_documents
-            (searchable_type, searchable_id, content, created_at, updated_at)
+            (searchable_type, searchable_subclass_type, searchable_id, content, created_at, updated_at)
             VALUES
-            ('Bar', 123, 'foo', now(), now());
+            ('Bar', 'Bar', 123, 'foo', now(), now());
         SQL
         expect(PgSearch::Document.count).to eq(2)
       end
@@ -117,9 +117,10 @@ describe PgSearch::Multisearch do
 
         it "should generate the proper SQL code" do
           expected_sql = <<-SQL.strip_heredoc
-            INSERT INTO #{PgSearch::Document.quoted_table_name} (searchable_type, searchable_id, content, created_at, updated_at)
-              SELECT #{connection.quote(model.name)} AS searchable_type,
+            INSERT INTO #{PgSearch::Document.quoted_table_name} (searchable_type, searchable_id, searchable_subclass_type, content, created_at, updated_at)
+              SELECT #{connection.quote(model.base_class.name)} AS searchable_type,
                      #{model.quoted_table_name}.id AS searchable_id,
+                     #{connection.quote(model.name)} AS searchable_subclass_type,
                      (
                        coalesce(#{model.quoted_table_name}.title::text, '')
                      ) AS content,
@@ -144,9 +145,10 @@ describe PgSearch::Multisearch do
 
         it "should generate the proper SQL code" do
           expected_sql = <<-SQL.strip_heredoc
-            INSERT INTO #{PgSearch::Document.quoted_table_name} (searchable_type, searchable_id, content, created_at, updated_at)
-              SELECT #{connection.quote(model.name)} AS searchable_type,
+            INSERT INTO #{PgSearch::Document.quoted_table_name} (searchable_type, searchable_id, searchable_subclass_type, content, created_at, updated_at)
+              SELECT #{connection.quote(model.base_class.name)} AS searchable_type,
                      #{model.quoted_table_name}.id AS searchable_id,
+                     #{connection.quote(model.name)} AS searchable_subclass_type,
                      (
                        coalesce(#{model.quoted_table_name}.title::text, '') || ' ' || coalesce(#{model.quoted_table_name}.content::text, '')
                      ) AS content,

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -17,5 +17,6 @@ require 'support/with_model'
 DOCUMENTS_SCHEMA = lambda do |t|
   t.belongs_to :searchable, :polymorphic => true
   t.text :content
+  t.string :searchable_subclass_type
   t.timestamps null: false
 end


### PR DESCRIPTION
Enables rebuilding of STI subclass correctly. See bug report https://github.com/Casecommons/pg_search/pull/225. @nertzy not sure if this is the correct way to add table column.