### PR TITLE
Support STI models using self.inheritance_column

### DIFF
--- a/lib/pg_search/multisearch/rebuilder.rb
+++ b/lib/pg_search/multisearch/rebuilder.rb
@@ -54,12 +54,12 @@ module PgSearch
 
       def sti_clause
         clause = ""
-        if model.column_names.include? 'type'
+        if model.column_names.include? model.inheritance_column
           clause = "WHERE"
           if model.base_class == model
-            clause = "#{clause} type IS NULL OR"
+            clause = "#{clause} #{model.inheritance_column} IS NULL OR"
           end
-          clause = "#{clause} type = #{model_name}"
+          clause = "#{clause} #{model.inheritance_column} = #{model_name}"
         end
         clause
       end

--- a/spec/lib/pg_search_spec.rb
+++ b/spec/lib/pg_search_spec.rb
@@ -78,7 +78,11 @@ describe PgSearch do
       with_model :SuperclassModel do
         table do |t|
           t.text 'content'
-          t.string 'type'
+          t.string 'inherit'
+        end
+
+        model do
+          self.inheritance_column = 'inherit'
         end
       end
 


### PR DESCRIPTION
We're using this gem and it's proven really useful, but we ran into a couple of problems with the standard multisearch document builder due to our STI models.

This pull request checks the model's inheritance_column instead of the existence of the 'type' column. It's important to check for two reasons:

* models might use a field other than "type" for inheritance (covered in a test)
* the model's table may have a "type" column that is not for Rails STI, so they set inheritance_column to nil (our situation)

I'm getting Rubocop problems on Travis, but not in files that I edited? Let me know what I can do to make this PR better.