### PR TITLE
Don’t use SQL to rebuild dynamic multisearchable

### DIFF
--- a/lib/pg_search/multisearch/rebuilder.rb
+++ b/lib/pg_search/multisearch/rebuilder.rb
@@ -13,7 +13,7 @@ module PgSearch
       def rebuild
         if model.respond_to?(:rebuild_pg_search_documents)
           model.rebuild_pg_search_documents
-        elsif model.pg_search_multisearchable_options.key?(:if) || model.pg_search_multisearchable_options.key?(:unless)
+        elsif conditional? || dynamic?
           model.find_each { |record| record.update_pg_search_document }
         else
           model.connection.execute(rebuild_sql)
@@ -23,6 +23,15 @@ module PgSearch
       private
 
       attr_reader :model
+
+      def conditional?
+        model.pg_search_multisearchable_options.key?(:if) || model.pg_search_multisearchable_options.key?(:unless)
+      end
+
+      def dynamic?
+        column_names = model.columns.map(&:name)
+        columns.any? { |column| !column_names.include?(column.to_s) }
+      end
 
       def connection
         model.connection

--- a/spec/lib/pg_search/multisearch/rebuilder_spec.rb
+++ b/spec/lib/pg_search/multisearch/rebuilder_spec.rb
@@ -23,7 +23,7 @@ describe PgSearch::Multisearch::Rebuilder do
         end
       end
 
-      context "when multisearch is conditional" do
+      context "and multisearchable is conditional" do
         [:if, :unless].each do |conditional_key|
           context "via :#{conditional_key}" do
             with_model :Model do
@@ -51,82 +51,10 @@ describe PgSearch::Multisearch::Rebuilder do
     end
 
     context "when the model does not define .rebuild_pg_search_documents" do
-      context "when multisearchable is not conditional" do
-        with_model :Model do
-          table do |t|
-            t.string :name
-          end
-
-          model do
-            include PgSearch
-            multisearchable :against => :name
-          end
-        end
-
-        it "should not call :rebuild_pg_search_documents" do
-          rebuilder = PgSearch::Multisearch::Rebuilder.new(Model)
-
-          # stub respond_to? to return false since should_not_receive defines the method
-          original_respond_to = Model.method(:respond_to?)
-          allow(Model).to receive(:respond_to?) do |method_name, *args|
-            if method_name == :rebuild_pg_search_documents
-              false
-            else
-              original_respond_to.call(method_name, *args)
-            end
-          end
-
-          expect(Model).not_to receive(:rebuild_pg_search_documents)
-          rebuilder.rebuild
-        end
-
-        it "should execute the default SQL" do
-          time = DateTime.parse("2001-01-01")
-          rebuilder = PgSearch::Multisearch::Rebuilder.new(Model, lambda { time } )
-
-          # Handle change in precision of DateTime objects in SQL in Active Record 4.0.1
-          # https://github.com/rails/rails/commit/17f5d8e062909f1fcae25351834d8e89967b645e
-          version_4_0_1_or_newer = (
-            (ActiveRecord::VERSION::MAJOR > 4) ||
-            (ActiveRecord::VERSION::MAJOR == 4 && ActiveRecord::VERSION::MINOR >= 1) ||
-            (ActiveRecord::VERSION::MAJOR == 4 && ActiveRecord::VERSION::MINOR == 0 && ActiveRecord::VERSION::TINY >= 1)
-          )
-
-          expected_timestamp =
-            if version_4_0_1_or_newer
-              "2001-01-01 00:00:00.000000"
-            else
-              "2001-01-01 00:00:00"
-            end
-
-          expected_sql = <<-SQL.strip_heredoc
-            INSERT INTO "pg_search_documents" (searchable_type, searchable_id, content, created_at, updated_at)
-              SELECT 'Model' AS searchable_type,
-                     #{Model.quoted_table_name}.#{Model.primary_key} AS searchable_id,
-                     (
-                       coalesce(#{Model.quoted_table_name}.name::text, '')
-                     ) AS content,
-                     '#{expected_timestamp}' AS created_at,
-                     '#{expected_timestamp}' AS updated_at
-              FROM #{Model.quoted_table_name}
-          SQL
-
-          executed_sql = []
-
-          notifier = ActiveSupport::Notifications.subscribe("sql.active_record") do |name, start, finish, id, payload|
-            executed_sql << payload[:sql] if payload[:sql].include?(%Q{INSERT INTO "pg_search_documents"})
-          end
-
-          rebuilder.rebuild
-          ActiveSupport::Notifications.unsubscribe(notifier)
-
-          expect(executed_sql.length).to eq(1)
-          expect(executed_sql.first.strip).to eq(expected_sql.strip)
-        end
-
-        context "for a model with a non-standard primary key" do
-          with_model :ModelWithNonStandardPrimaryKey do
-            table primary_key: :non_standard_primary_key do |t|
+      context "and multisearchable is not conditional" do
+        context "when :against only includes columns" do
+          with_model :Model do
+            table do |t|
               t.string :name
             end
 
@@ -136,14 +64,31 @@ describe PgSearch::Multisearch::Rebuilder do
             end
           end
 
-          it "generates SQL with the correct primary key" do
+          it "should not call :rebuild_pg_search_documents" do
+            rebuilder = PgSearch::Multisearch::Rebuilder.new(Model)
+
+            # stub respond_to? to return false since should_not_receive defines the method
+            original_respond_to = Model.method(:respond_to?)
+            allow(Model).to receive(:respond_to?) do |method_name, *args|
+              if method_name == :rebuild_pg_search_documents
+                false
+              else
+                original_respond_to.call(method_name, *args)
+              end
+            end
+
+            expect(Model).not_to receive(:rebuild_pg_search_documents)
+            rebuilder.rebuild
+          end
+
+          it "should execute the default SQL" do
             time = DateTime.parse("2001-01-01")
-            rebuilder = PgSearch::Multisearch::Rebuilder.new(ModelWithNonStandardPrimaryKey, lambda { time } )
+            rebuilder = PgSearch::Multisearch::Rebuilder.new(Model, lambda { time } )
 
             # Handle change in precision of DateTime objects in SQL in Active Record 4.0.1
             # https://github.com/rails/rails/commit/17f5d8e062909f1fcae25351834d8e89967b645e
             version_4_0_1_or_newer = (
-              (ActiveRecord::VERSION::MAJOR > 4) ||
+            (ActiveRecord::VERSION::MAJOR > 4) ||
               (ActiveRecord::VERSION::MAJOR == 4 && ActiveRecord::VERSION::MINOR >= 1) ||
               (ActiveRecord::VERSION::MAJOR == 4 && ActiveRecord::VERSION::MINOR == 0 && ActiveRecord::VERSION::TINY >= 1)
             )
@@ -156,15 +101,15 @@ describe PgSearch::Multisearch::Rebuilder do
               end
 
             expected_sql = <<-SQL.strip_heredoc
-              INSERT INTO "pg_search_documents" (searchable_type, searchable_id, content, created_at, updated_at)
-                SELECT 'ModelWithNonStandardPrimaryKey' AS searchable_type,
-                       #{ModelWithNonStandardPrimaryKey.quoted_table_name}.non_standard_primary_key AS searchable_id,
-                       (
-                         coalesce(#{ModelWithNonStandardPrimaryKey.quoted_table_name}.name::text, '')
-                       ) AS content,
-                       '#{expected_timestamp}' AS created_at,
-                       '#{expected_timestamp}' AS updated_at
-                FROM #{ModelWithNonStandardPrimaryKey.quoted_table_name}
+            INSERT INTO "pg_search_documents" (searchable_type, searchable_id, content, created_at, updated_at)
+              SELECT 'Model' AS searchable_type,
+                     #{Model.quoted_table_name}.#{Model.primary_key} AS searchable_id,
+                     (
+                       coalesce(#{Model.quoted_table_name}.name::text, '')
+                     ) AS content,
+                     '#{expected_timestamp}' AS created_at,
+                     '#{expected_timestamp}' AS updated_at
+              FROM #{Model.quoted_table_name}
             SQL
 
             executed_sql = []
@@ -179,10 +124,104 @@ describe PgSearch::Multisearch::Rebuilder do
             expect(executed_sql.length).to eq(1)
             expect(executed_sql.first.strip).to eq(expected_sql.strip)
           end
+
+          context "for a model with a non-standard primary key" do
+            with_model :ModelWithNonStandardPrimaryKey do
+              table primary_key: :non_standard_primary_key do |t|
+                t.string :name
+              end
+
+              model do
+                include PgSearch
+                multisearchable :against => :name
+              end
+            end
+
+            it "generates SQL with the correct primary key" do
+              time = DateTime.parse("2001-01-01")
+              rebuilder = PgSearch::Multisearch::Rebuilder.new(ModelWithNonStandardPrimaryKey, lambda { time } )
+
+              # Handle change in precision of DateTime objects in SQL in Active Record 4.0.1
+              # https://github.com/rails/rails/commit/17f5d8e062909f1fcae25351834d8e89967b645e
+              version_4_0_1_or_newer = (
+              (ActiveRecord::VERSION::MAJOR > 4) ||
+                (ActiveRecord::VERSION::MAJOR == 4 && ActiveRecord::VERSION::MINOR >= 1) ||
+                (ActiveRecord::VERSION::MAJOR == 4 && ActiveRecord::VERSION::MINOR == 0 && ActiveRecord::VERSION::TINY >= 1)
+              )
+
+              expected_timestamp =
+                if version_4_0_1_or_newer
+                  "2001-01-01 00:00:00.000000"
+                else
+                  "2001-01-01 00:00:00"
+                end
+
+              expected_sql = <<-SQL.strip_heredoc
+              INSERT INTO "pg_search_documents" (searchable_type, searchable_id, content, created_at, updated_at)
+                SELECT 'ModelWithNonStandardPrimaryKey' AS searchable_type,
+                       #{ModelWithNonStandardPrimaryKey.quoted_table_name}.non_standard_primary_key AS searchable_id,
+                       (
+                         coalesce(#{ModelWithNonStandardPrimaryKey.quoted_table_name}.name::text, '')
+                       ) AS content,
+                       '#{expected_timestamp}' AS created_at,
+                       '#{expected_timestamp}' AS updated_at
+                FROM #{ModelWithNonStandardPrimaryKey.quoted_table_name}
+              SQL
+
+              executed_sql = []
+
+              notifier = ActiveSupport::Notifications.subscribe("sql.active_record") do |name, start, finish, id, payload|
+                executed_sql << payload[:sql] if payload[:sql].include?(%Q{INSERT INTO "pg_search_documents"})
+              end
+
+              rebuilder.rebuild
+              ActiveSupport::Notifications.unsubscribe(notifier)
+
+              expect(executed_sql.length).to eq(1)
+              expect(executed_sql.first.strip).to eq(expected_sql.strip)
+            end
+          end
+        end
+
+        context "when :against includes non-column dynamic methods" do
+          with_model :Model do
+            table do
+            end
+
+            model do
+              include PgSearch
+              multisearchable against: [:foo]
+
+              def foo
+                "bar"
+              end
+            end
+          end
+
+          it "calls update_pg_search_document on each record" do
+            record = Model.create!
+
+            rebuilder = PgSearch::Multisearch::Rebuilder.new(Model)
+
+            # stub respond_to? to return false since should_not_receive defines the method
+            original_respond_to = Model.method(:respond_to?)
+            allow(Model).to receive(:respond_to?) do |method_name, *args|
+              if method_name == :rebuild_pg_search_documents
+                false
+              else
+                original_respond_to.call(method_name, *args)
+              end
+            end
+            expect(Model).not_to receive(:rebuild_pg_search_documents)
+
+            rebuilder.rebuild
+
+            expect(record.pg_search_document).to be_present
+          end
         end
       end
 
-      context "when multisearchable is conditional" do
+      context "and multisearchable is conditional" do
         context "via :if" do
           with_model :Model do
             table do |t|


### PR DESCRIPTION
Iterate over each record with `find_each` instead.

Fixes #70