### PR TITLE
Enable chaining of pg_search scopes

### DIFF
--- a/lib/pg_search/scope_options.rb
+++ b/lib/pg_search/scope_options.rb
@@ -14,7 +14,11 @@ module PgSearch
 
     def apply(scope)
       unless scope.instance_variable_get(:@pg_search_scope_applied_count)
-        scope = scope.all.spawn
+        scope = if ::ActiveRecord::VERSION::STRING < "4.0.0"
+                  scope.scoped
+                else
+                  scope.all.spawn
+                end
       end
 
       alias_id = scope.instance_variable_get(:@pg_search_scope_applied_count) || 0

--- a/lib/pg_search/scope_options.rb
+++ b/lib/pg_search/scope_options.rb
@@ -13,9 +13,18 @@ module PgSearch
     end
 
     def apply(scope)
+      unless scope.instance_variable_get(:@scope_applied_count)
+        scope = scope.all.spawn
+      end
+
+      alias_id = scope.instance_variable_get(:@scope_applied_count) || 0
+      scope.instance_variable_set(:@scope_applied_count, alias_id + 1)
+
+      aka = pg_search_alias scope, alias_id
+
       scope
-        .joins(rank_join)
-        .order("pg_search.rank DESC, #{order_within_rank}")
+        .joins(rank_join(aka))
+        .order("#{aka}.rank DESC, #{order_within_rank}")
         .extend(DisableEagerLoading)
         .extend(WithPgSearchRank)
     end
@@ -31,7 +40,10 @@ module PgSearch
       def with_pg_search_rank
         scope = self
         scope = scope.select("*") unless scope.select_values.any?
-        scope.select("pg_search.rank AS pg_search_rank")
+        arel_table = scope.instance_variable_get(:@table)
+        aka = "pg_search_#{arel_table.name}"
+
+        scope.select("#{aka}.rank AS pg_search_rank")
       end
     end
 
@@ -105,8 +117,15 @@ module PgSearch
       end
     end
 
-    def rank_join
-      "INNER JOIN (#{subquery.to_sql}) pg_search ON #{primary_key} = pg_search.pg_search_id"
+    def pg_search_alias(scope, n)
+      arel_table = scope.instance_variable_get(:@table)
+      prefix = "pg_search_#{arel_table.name}"
+
+      0 == n ? prefix : "#{prefix}_#{n}"
+    end
+
+    def rank_join(aka)
+      "INNER JOIN (#{subquery.to_sql}) #{aka} ON #{primary_key} = #{aka}.pg_search_id"
     end
   end
 end

--- a/lib/pg_search/scope_options.rb
+++ b/lib/pg_search/scope_options.rb
@@ -13,12 +13,12 @@ module PgSearch
     end
 
     def apply(scope)
-      unless scope.instance_variable_get(:@scope_applied_count)
+      unless scope.instance_variable_get(:@pg_search_scope_applied_count)
         scope = scope.all.spawn
       end
 
-      alias_id = scope.instance_variable_get(:@scope_applied_count) || 0
-      scope.instance_variable_set(:@scope_applied_count, alias_id + 1)
+      alias_id = scope.instance_variable_get(:@pg_search_scope_applied_count) || 0
+      scope.instance_variable_set(:@pg_search_scope_applied_count, alias_id + 1)
 
       aka = pg_search_alias scope, alias_id
 

--- a/spec/integration/pg_search_spec.rb
+++ b/spec/integration/pg_search_spec.rb
@@ -256,7 +256,7 @@ describe "an Active Record model which includes PgSearch" do
           it "does not raise an exception" do
             relation = Person.named('foo').house_search_city('bar')
 
-            expect { relation.load }.to_not raise_error
+            expect { relation.to_a }.to_not raise_error
           end
         end
       end
@@ -269,7 +269,7 @@ describe "an Active Record model which includes PgSearch" do
         it "does not raise an exception" do
           relation = ModelWithPgSearch.search_content('foo').search_title('bar')
 
-          expect { relation.load }.to_not raise_error
+          expect { relation.to_a }.to_not raise_error
         end
       end
 

--- a/spec/integration/pg_search_spec.rb
+++ b/spec/integration/pg_search_spec.rb
@@ -194,7 +194,9 @@ describe "an Active Record model which includes PgSearch" do
           end
 
           model do
+            include PgSearch
             belongs_to :person
+            pg_search_scope :search_city, against: [:city]
           end
         end
 
@@ -207,8 +209,11 @@ describe "an Active Record model which includes PgSearch" do
             include PgSearch
             has_many :houses
             pg_search_scope :named, against: [:name]
-            scope :with_house_in_city, ->(city) {
+            scope :with_house_in_city, -> (city) {
               joins(:houses).where(House.table_name.to_sym => {city: city})
+            }
+            scope :house_search_city, -> (query) {
+              joins(:houses).merge(House.search_city(query))
             }
           end
         end
@@ -245,6 +250,26 @@ describe "an Active Record model which includes PgSearch" do
           results = Person.with_house_in_city("Duluth").named("Bob")
           expect(results).to include bob_in_duluth
           expect(results).not_to include [bob_in_sheboygan, sally_in_duluth]
+        end
+
+        context "when chaining merged scopes" do
+          it "does not raise an exception" do
+            relation = Person.named('foo').house_search_city('bar')
+
+            expect { relation.load }.to_not raise_error
+          end
+        end
+      end
+
+      context "when chaining scopes" do
+        before do
+          ModelWithPgSearch.pg_search_scope :search_title, against: :title
+        end
+
+        it "does not raise an exception" do
+          relation = ModelWithPgSearch.search_content('foo').search_title('bar')
+
+          expect { relation.load }.to_not raise_error
         end
       end
 
@@ -307,7 +332,7 @@ describe "an Active Record model which includes PgSearch" do
         twice = ModelWithPgSearch.create!(:content => 'foo foo')
 
         records = ModelWithPgSearch.search_content('foo')
-                  .where("pg_search.rank > 0.07")
+                  .where("pg_search_#{ModelWithPgSearch.table_name}.rank > 0.07")
 
         expect(records).to eq [twice]
       end

--- a/spec/integration/pg_search_spec.rb
+++ b/spec/integration/pg_search_spec.rb
@@ -209,10 +209,10 @@ describe "an Active Record model which includes PgSearch" do
             include PgSearch
             has_many :houses
             pg_search_scope :named, against: [:name]
-            scope :with_house_in_city, -> (city) {
+            scope :with_house_in_city, ->(city) {
               joins(:houses).where(House.table_name.to_sym => {city: city})
             }
-            scope :house_search_city, -> (query) {
+            scope :house_search_city, ->(query) {
               joins(:houses).merge(House.search_city(query))
             }
           end


### PR DESCRIPTION
### Description

This patch include two spec examples, one for the simple case of chaining
scopes and the other for the case where two relations are being merged.

To fix the first issue, I've expanded on @davearonson solution by using
an instance variable in the given scope instead of a class variable. To
prevent polluting the given relation, the code spawn a new relation if
the variable is missing.

Using this variable as a counter the pg_search scope pseudo-table is
aliased with the current count as a suffix if it's not the first
one. This let us not having to dynamically generate the
`with_pg_search_rank` method which use the first scope for rank.

Finally to fix merged relations, the table name is used in the pg_search
scope pseudo-table aliases.

### Example

Given the following AR query:

```ruby
> Person.named('foo')
        .joins(:houses)
        .merge(House.search_city('bar'))
```
We'll get the following SQL:

```sql
SELECT "people".*, pg_search_people.rank AS pg_search_rank FROM "people"
INNER JOIN "houses" ON "houses"."person_id" = "people"."id"
INNER JOIN <inner query> pg_search_people ON "people"."id" = pg_search_people.pg_search_id
INNER JOIN <inner query> pg_search_houses ON "houses"."id" = pg_search_houses.pg_search_id
ORDER BY pg_search_people.rank DESC, "people"."id" ASC,
         pg_search_houses.rank DESC, "houses"."id" ASC
```