### PR TITLE
Clean up rank table aliasing

### DIFF
--- a/lib/pg_search/scope_options.rb
+++ b/lib/pg_search/scope_options.rb
@@ -44,8 +44,7 @@ module PgSearch
       def with_pg_search_rank
         scope = self
         scope = scope.select("*") unless scope.select_values.any?
-        arel_table = scope.instance_variable_get(:@table)
-        aka = "pg_search_#{arel_table.name}"
+        aka = "pg_search_#{scope.arel_table.name}"
 
         scope.select("#{aka}.rank AS pg_search_rank")
       end
@@ -121,10 +120,8 @@ module PgSearch
       end
     end
 
-    def pg_search_alias(scope, n)
-      arel_table = scope.instance_variable_get(:@table)
-      prefix = "pg_search_#{arel_table.name}"
-
+    def pg_search_alias(scope, n = 0)
+      prefix = "pg_search_#{scope.arel_table.name}"
       0 == n ? prefix : "#{prefix}_#{n}"
     end
 

--- a/lib/pg_search/scope_options.rb
+++ b/lib/pg_search/scope_options.rb
@@ -40,13 +40,13 @@ module PgSearch
 
     module PgSearchRankTableAliasing
       def pg_search_rank_table_alias(include_counter = false)
-        prefix = "pg_search_#{arel_table.name}"
+        components = [arel_table.name]
         if include_counter
           count = pg_search_scope_application_count_plus_plus
-          count.zero? ? prefix : "#{prefix}_#{count}"
-        else
-          prefix
+          components << count if count > 0
         end
+
+        Configuration.alias(components)
       end
 
       private

--- a/spec/integration/pg_search_spec.rb
+++ b/spec/integration/pg_search_spec.rb
@@ -332,7 +332,7 @@ describe "an Active Record model which includes PgSearch" do
         twice = ModelWithPgSearch.create!(:content => 'foo foo')
 
         records = ModelWithPgSearch.search_content('foo')
-                  .where("pg_search_#{ModelWithPgSearch.table_name}.rank > 0.07")
+                  .where("#{PgSearch::Configuration.alias(ModelWithPgSearch.table_name)}.rank > 0.07")
 
         expect(records).to eq [twice]
       end


### PR DESCRIPTION
This is a followup to issue #1.  The changes introduced to resolve that issue made a fairly significant breaking change: the search rank subquery no longer has a consistent name.  For uses of PgSearch with complex queries, particularly queries that require GROUP BY clauses, you need the name of the subquery.  Unfortunately, the code that generates the alias for the subquery was buried as a private method in ScopeOptions.

This series of commits makes the generation of the subquery alias more consistent, makes it publicly available by re-using the already available `.alias` method on the PgSearch::Configuration class, eliminates some access control violations, and updates the documentation to more correctly describe what's going on with pg_search_rank.

Importantly, these changes do not resolve the fact that the `.with_pg_search_rank` will only return the the rank of the *first* scope included in the case where scopes are chained.

Honestly, I'd like to see code that requires chained scopes moving out of ActiveRecord scopes and into separate query objects, but that is a separate discussion.