### PR TITLE
pg_search_rank with join fixed with spec

### DIFF
--- a/lib/pg_search/scope_options.rb
+++ b/lib/pg_search/scope_options.rb
@@ -33,7 +33,7 @@ module PgSearch
     module WithPgSearchRank
       def with_pg_search_rank
         scope = self
-        scope = scope.select("*") unless scope.select_values.any?
+        scope = scope.select("#{table_name}.*") unless scope.select_values.any?
         scope.select("#{pg_search_rank_table_alias}.rank AS pg_search_rank")
       end
     end
@@ -148,4 +148,3 @@ module PgSearch
     end
   end
 end
-


### PR DESCRIPTION
Currently using pg_search_rank along with a join fails due to id column collision of the two tables. Here's the fix for that with working specs.