### PR TITLE
Add option to disable ranking of results entirely.

### DIFF
--- a/lib/pg_search/configuration.rb
+++ b/lib/pg_search/configuration.rb
@@ -88,7 +88,7 @@ module PgSearch
     ].map(&:to_sym)
 
     VALID_VALUES = {
-      :ignoring => [:accents]
+      :ignoring => [:accents, :rank]
     }
 
     def assert_valid_options(options)

--- a/spec/integration/pg_search_spec.rb
+++ b/spec/integration/pg_search_spec.rb
@@ -1097,6 +1097,19 @@ describe "an Active Record model which includes PgSearch" do
       end
     end
 
+    context "ignoring rank" do
+      before do
+        ModelWithPgSearch.pg_search_scope :search_title_without_rank,
+          :against => :title,
+          :ignoring => :rank
+      end
+
+      it "does not use ts_rank in the query" do
+        sql = ModelWithPgSearch.search_title_without_rank("foobar").to_sql
+        expect(sql).to_not include "ts_rank"
+      end
+    end
+
     context "when passed a :ranked_by expression" do
       before do
         ModelWithPgSearch.pg_search_scope :search_content_with_default_rank,


### PR DESCRIPTION
This PR adds the option to set `ignoring = :rank`, which will cause pg_search to skip ordering the search results entirely, and to remove all calls to ts_rank from the query.

This change allows for much faster queries where ranking isn't important, especially where the search terms may match thousands of documents.