### PR TITLE
pg_search_scope accepts a second argument to override options

### DIFF
--- a/README.md
+++ b/README.md
@@ -579,6 +579,23 @@ robin = Superhero.create :name => 'Robin'
 
 Superhero.whose_name_starts_with("Bat") # => [batman, batgirl]
 ```
+
+Note that you can override the prefix option on an especific query like this:
+
+```ruby
+class Superhero < ActiveRecord::Base
+  include PgSearch
+  pg_search_scope :search,
+                  :against => :name,
+                  :using => {
+                    :tsearch => {:prefix => true}
+                  }
+end
+
+Superhero.create :name => 'Batman'
+Superhero.search("Bat", using: { :tsearch => { :prefix => false }}) # => []
+```
+
 ##### :negation
 
 PostgreSQL's full text search matches all search terms by default. If you want

--- a/lib/pg_search.rb
+++ b/lib/pg_search.rb
@@ -30,7 +30,7 @@ module PgSearch
                        unless options.respond_to?(:merge)
                          raise ArgumentError, "pg_search_scope expects a Hash or Proc"
                        end
-                       ->(query) { {:query => query}.merge(options) }
+                       ->(query, override_options = {}) { {:query => query}.merge(options).deep_merge(override_options) }
                      end
 
       define_singleton_method(name) do |*args|

--- a/spec/integration/pg_search_spec.rb
+++ b/spec/integration/pg_search_spec.rb
@@ -596,6 +596,15 @@ describe "an Active Record model which includes PgSearch" do
             expect(results).to include(included)
             expect(results).not_to include(excluded)
           end
+
+          context "with an { using: { tsearch: { prefix: false }}} options" do
+            it "returns rows that match the query but not rows that are prefixed by the query" do
+              excluded = ModelWithPgSearch.create!(:title => 'prefix')
+
+              results = ModelWithPgSearch.search_title_with_prefixes("pre", using: { tsearch: { prefix: false }})
+              expect(results).not_to include(excluded)
+            end
+          end
         end
       end
 


### PR DESCRIPTION
This commits add a second argument to `pg_search_scope` so devs doesn't need to create another scope when needing to change an option in some scenarios.