### PR TITLE
Fix for #257 - nil options in tsearch.

### DIFF
--- a/lib/pg_search/features/feature.rb
+++ b/lib/pg_search/features/feature.rb
@@ -20,10 +20,14 @@ module PgSearch
 
       private
 
-      attr_reader :query, :options, :all_columns, :model, :normalizer
+      attr_reader :query, :all_columns, :model, :normalizer
 
       def document
         columns.map { |column| column.to_sql }.join(" || ' ' || ")
+      end
+
+      def options
+        @options ||= {}
       end
 
       def columns


### PR DESCRIPTION
I ran into issue #257 on my first time setting up pg_search.  I thought it was because the model I was working with was in a module, but I tested it in a plain vanilla Rails 4 model and got the exact same error.

The fix is basically converting `Features`'s `options` `attr_reader` into a method that sets it to an empty `Hash` if it's `nil`.  I couldn't figure out why that wasn't happening in the initialize method, but this fixed my error and all the tests still pass, so I figured it was good enough.

Thanks!