### PR TITLE
multisearchable: Add callback (:pg_search_document_update) to allow s…

### DIFF
--- a/lib/pg_search/multisearchable.rb
+++ b/lib/pg_search/multisearchable.rb
@@ -23,7 +23,9 @@ module PgSearch
         unless_conditions.all? { |condition| !condition.to_proc.call(self) }
 
       if should_have_document
-        pg_search_document ? pg_search_document.save : create_pg_search_document
+        create_pg_search_document if pg_search_document.nil?
+        pg_search_document_update(pg_search_document) if self.respond_to?(:pg_search_document_update)
+        pg_search_document.save
       else
         pg_search_document.destroy if pg_search_document
       end


### PR DESCRIPTION
…ubclasses to respond to / stash custom properties on the search document.

For example, one might want to include a permission mask on each record and exclude records for a given query, based on user permissions.

Currently, there isn't a way for pg_search clients to get notified when the pg_search_document is going to be updated.

It's true that I could just wire up my own :after_save callback, but I'd rather not perform multiple updates to the same record.

This change simply checks for the existence of a ```:pg_search_document_update``` method, and calls it, passing the document, if it's going to update the search doc.