### PR TITLE
add note about trigram thresholds and indexes

### DIFF
--- a/README.md
+++ b/README.md
@@ -805,7 +805,9 @@ Website.kinda_spelled_like("Yahoo!") # => [yahooo, yohoo]
 By default, trigram searches find records which have a similarity of at least 0.3
 using pg_trgm's calculations. You may specify a custom threshold if you prefer.
 Higher numbers match more strictly, and thus return fewer results. Lower numbers
-match more permissively, letting in more results.
+match more permissively, letting in more results. Please note that setting a trigram
+threshold will force a table scan as the derived query uses the
+`similarity()` function instead of the `%` operator.
 
 ```ruby
 class Vegetable < ActiveRecord::Base


### PR DESCRIPTION
linked to #278 - add a note to the readme outlining the query implications of setting a threshold query for trigram searching.

I agree it'd be nicer to have the similarity query hit the index but in the meantime letting users know that the index will be skipped should suffice.