### PR TITLE
Add total count for group by searchable_type example

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,6 +244,7 @@ PgSearch.multisearch("Alamo").page(3).per(30)
 PgSearch.multisearch("Diagonal").find_each do |document|
   puts document.searchable.updated_at
 end
+PgSearch.multisearch('Moro').reorder('').group(:searchable_type).count(:all)
 ```
 
 #### Configuring multi-search

--- a/README.md
+++ b/README.md
@@ -244,7 +244,8 @@ PgSearch.multisearch("Alamo").page(3).per(30)
 PgSearch.multisearch("Diagonal").find_each do |document|
   puts document.searchable.updated_at
 end
-PgSearch.multisearch('Moro').reorder('').group(:searchable_type).count(:all)
+PgSearch.multisearch("Moro").reorder("").group(:searchable_type).count(:all)
+PgSearch.multisearch("Square").includes(:searchable)
 ```
 
 #### Configuring multi-search


### PR DESCRIPTION
Hello @nertzy 

It took me a couple of hours to figure how to do a composite count for each searchable_type it and as I see some issues relating count I thought this example would eventually become handy to other folks in the future.

As you encouraged in #180 ([here](https://github.com/Casecommons/pg_search/issues/180#issuecomment-46340091)), I am sending this pull request as it is probably going to clarify both count and group scenarios in one place.

Hope it helps!