### PR TITLE
Conditional override for :dictionary key

### DIFF
--- a/lib/pg_search/features/dmetaphone.rb
+++ b/lib/pg_search/features/dmetaphone.rb
@@ -3,7 +3,8 @@ module PgSearch
     class DMetaphone
       def initialize(query, options, columns, model, normalizer)
         dmetaphone_normalizer = Normalizer.new(normalizer)
-        options = (options || {}).merge(:dictionary => 'simple')
+        options ||= {}
+        options.merge(:dictionary => 'simple') unless options.key?(:dictionary)
         @tsearch = TSearch.new(query, options, columns, model, dmetaphone_normalizer)
       end
 


### PR DESCRIPTION
The way it is, there is no way to specify a different dictionary than `simple` for DMetaphone class.
