### PR TITLE
pass dictionary to ts_headline()

### DIFF
--- a/lib/pg_search/features/tsearch.rb
+++ b/lib/pg_search/features/tsearch.rb
@@ -47,7 +47,7 @@ module PgSearch
       end
 
       def ts_headline
-        "ts_headline((#{document}), (#{tsquery}), '#{ts_headline_options}')"
+        "ts_headline(#{dictionary.to_sql}, (#{document}), (#{tsquery}), '#{ts_headline_options}')"
       end
 
       def ts_headline_options


### PR DESCRIPTION
otherwise it breaks when scope uses non-default dictionary (the query
and highlight use incompatible dictionaries then)