### PR TITLE
Fix error in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -749,8 +749,10 @@ class Person < ActiveRecord::Base
                   :against => :bio,
                   :using => {
                     :tsearch => {
-                      :start_sel => '<b>',
-                      :stop_sel => '</b>'
+                      :highlight => {
+                        :start_sel => '<b>',
+                        :stop_sel => '</b>'
+                      }
                     }
                   }
 end


### PR DESCRIPTION
Using the 'highlight' feature as described in the README does not work; the `highlight` options had to go under their own key, or for default behavior, `highlight: true` worked. I updated the README to match the behavior I observed.

