### PR TITLE
Wait to load PgSearch::Document until after ActiveRecord has loaded

### DIFF
--- a/lib/pg_search.rb
+++ b/lib/pg_search.rb
@@ -108,5 +108,8 @@ module PgSearch
   end
 end
 
-require "pg_search/document"
+ActiveSupport.on_load(:active_record) do
+  require "pg_search/document"
+end
+
 require "pg_search/railtie" if defined?(Rails)


### PR DESCRIPTION
Loading the PgSearch::Document model without waiting for ActiveRecord to
load can cause problems because it causes ActiveRecord to pull
configuration into ActiveRecord::Base before the initializers get
loaded. This means ActiveRecord::Base could accidentally have inaccurate
configuration.

The fix for this is to wait until ActiveRecord has fully loaded before
requiring the model.

ref: rails/rails#23589
