### PR TITLE
Fixed highlight problem when a stemming dictionary is configured.

### DIFF
--- a/lib/pg_search/features/tsearch.rb
+++ b/lib/pg_search/features/tsearch.rb
@@ -46,7 +46,7 @@ module PgSearch
       end
 
       def ts_headline
-        "ts_headline((#{document}), (#{tsquery}), '#{ts_headline_options}')"
+        "ts_headline(#{dictionary.to_sql}, (#{document}), (#{tsquery}), '#{ts_headline_options}')"
       end
 
       def ts_headline_options


### PR DESCRIPTION
Hi,
We a re using pg_search with languages and we are notice that the resulting snippets are not wrapped with tags if a dictionary is selected.

I am using pg_search 1.0.6, ruby 2.3.1 and active_record 4.2.4

A minimal script that reproduces the problem:

``` ruby
require 'active_record'
require 'pg_search'

ActiveRecord::Base.logger = Logger.new(STDOUT)
ActiveRecord::Base.establish_connection(
  adapter: 'postgresql',
  database: 'problem',
  username: 'user',
  password: 'password'
)
unless ActiveRecord::Base.connection.table_exists?(:tests)
  ActiveRecord::Base.connection.create_table :tests do |t|
    t.text :body
  end
end

class Test < ActiveRecord::Base
  include PgSearch

  pg_search_scope :search_es,
                  against: :body,
                  using: {
                    tsearch: {
                      dictionary: 'spanish',
                      highlight: {
                        start_sel: '<b>',
                        stop_sel: '</b>'
                      }
                    },
                  }
  pg_search_scope :search,
                  against: :body,
                  using: {
                    tsearch: {
                      highlight: {
                        start_sel: '<b>',
                        stop_sel: '</b>'
                      }
                    },
                  }
end

Test.create!(body: 'La filosofía occidental ha tenido una profunda influencia y se ha visto profundamente influida por la ciencia, la religión y la política occidentales.')

puts Test.search_es('ciencia').with_pg_search_highlight.first.pg_search_highlight
# => La filosofía occidental ha tenido una profunda influencia y se ha visto profundamente influida por

puts Test.search('ciencia').with_pg_search_highlight.first.pg_search_highlight
# => influencia y se ha visto profundamente influida por la <b>ciencia</b>, la religión y la política occidentales.
```

In the first case, using the Spanish dictionary, the word 'ciencia' was not wrapped with `<b>` tags. 
If the dictionary option is omitted,  pg_search works as expected.

The generated query in the first case omitted the first parameter of `ts_headline`, so I have fixed this using the default dictionary ('simple') in case of none selected.
Regards.
