### PR TITLE
avoid calling protected methods on connection object

### DIFF
--- a/lib/pg_search/configuration.rb
+++ b/lib/pg_search/configuration.rb
@@ -72,7 +72,7 @@ module PgSearch
     end
 
     def postgresql_version
-      model.connection.send(:postgresql_version)
+      model.connection.raw_connection.server_version
     end
 
     private

--- a/lib/pg_search/configuration/association.rb
+++ b/lib/pg_search/configuration/association.rb
@@ -42,7 +42,7 @@ module PgSearch
       end
 
       def selects_for_multiple_association
-        postgresql_version = @model.connection.send(:postgresql_version)
+        postgresql_version = @model.connection.raw_connection.server_version
 
         columns.map do |column|
           case postgresql_version

--- a/lib/pg_search/features/tsearch.rb
+++ b/lib/pg_search/features/tsearch.rb
@@ -30,7 +30,7 @@ module PgSearch
       private
 
       def checks_for_prefix
-        if options[:prefix] && model.connection.send(:postgresql_version) < 80400
+        if options[:prefix] && model.connection.raw_connection.server_version < 80400
           raise PgSearch::NotSupportedForPostgresqlVersion.new(<<-MESSAGE.strip_heredoc)
             Sorry, {:using => {:tsearch => {:prefix => true}}} only works in PostgreSQL 8.4 and above.")
           MESSAGE
@@ -38,7 +38,7 @@ module PgSearch
       end
 
       def checks_for_highlight
-        if options[:highlight] && model.connection.send(:postgresql_version) < 90000
+        if options[:highlight] && model.connection.raw_connection.server_version < 90000
           raise PgSearch::NotSupportedForPostgresqlVersion.new(<<-MESSAGE.strip_heredoc)
             Sorry, {:using => {:tsearch => {:highlight => true}}} only works in PostgreSQL 9.0 and above.")
           MESSAGE

--- a/spec/lib/pg_search/configuration/association_spec.rb
+++ b/spec/lib/pg_search/configuration/association_spec.rb
@@ -128,7 +128,7 @@ describe PgSearch::Configuration::Association do
         end
 
         it "returns the correct SQL join" do
-          allow(Site.connection).to receive(:postgresql_version).and_return(1)
+          allow(Site.connection.raw_connection).to receive(:server_version).and_return(1)
           expect(association.join("model_id")).to eq(expected_sql)
         end
       end
@@ -139,7 +139,7 @@ describe PgSearch::Configuration::Association do
         end
 
         it "returns the correct SQL join" do
-          allow(Site.connection).to receive(:postgresql_version).and_return(100_000)
+          allow(Site.connection.raw_connection).to receive(:server_version).and_return(100_000)
           expect(association.join("model_id")).to eq(expected_sql)
         end
       end


### PR DESCRIPTION
Calling protected methods on connection object breaks interoperability and causes issues with other gems e.g `activerecord_autoreplica`. We can access the same value over public method: `raw_connection.server_version`.