### PR TITLE
removed require "pg_search/migration/associated_against_generator"

### DIFF
--- a/lib/pg_search/railtie.rb
+++ b/lib/pg_search/railtie.rb
@@ -7,7 +7,6 @@ module PgSearch
     generators do
       require "pg_search/migration/multisearch_generator"
       require "pg_search/migration/dmetaphone_generator"
-      require "pg_search/migration/associated_against_generator"
     end
   end
 end


### PR DESCRIPTION
removed require "pg_search/migration/associated_against_generator" as its deleted from v2.0.0