### PR TITLE
Do not save already destroyed pg_search_document, take 3

### DIFF
--- a/lib/pg_search/multisearchable.rb
+++ b/lib/pg_search/multisearchable.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "active_support/core_ext/class/attribute"
 
 module PgSearch
@@ -31,6 +32,7 @@ module PgSearch
     end
 
     def should_update_pg_search_document?
+      return false if pg_search_document.destroyed?
       conditions = Array(pg_search_multisearchable_options[:update_if])
       conditions.all? { |condition| condition.to_proc.call(self) }
     end

--- a/spec/lib/pg_search/multisearchable_spec.rb
+++ b/spec/lib/pg_search/multisearchable_spec.rb
@@ -11,6 +11,33 @@ describe PgSearch::Multisearchable do
       end
     end
 
+    with_model :MultisearchableParent do
+      table do |t|
+        t.string :secret
+      end
+
+      model do
+        include PgSearch
+        multisearchable
+
+        has_many :multisearchable_children, :dependent => :destroy
+      end
+    end
+
+    with_model :MultisearchableChild do
+      table do |t|
+        t.belongs_to :multisearchable_parent
+      end
+
+      model do
+        belongs_to :multisearchable_parent
+
+        after_destroy do
+          multisearchable_parent.update_attribute(:secret, rand(1000).to_s)
+        end
+      end
+    end
+
     describe "callbacks" do
       describe "after_create" do
         let(:record) { ModelThatIsMultisearchable.new }
@@ -90,6 +117,18 @@ describe PgSearch::Multisearchable do
           record = ModelThatIsMultisearchable.create!
           document = record.pg_search_document
           expect { record.destroy }.to change(PgSearch::Document, :count).by(-1)
+          expect { PgSearch::Document.find(document.id) }.to raise_error(ActiveRecord::RecordNotFound)
+        end
+
+        it "should remove its document in case of complex associations" do
+          parent = MultisearchableParent.create!
+
+          MultisearchableChild.create!(multisearchable_parent: parent)
+          MultisearchableChild.create!(multisearchable_parent: parent)
+
+          document = parent.pg_search_document
+
+          expect { parent.destroy }.to change(PgSearch::Document, :count).by(-1)
           expect { PgSearch::Document.find(document.id) }.to raise_error(ActiveRecord::RecordNotFound)
         end
       end


### PR DESCRIPTION
Old pull-requests:

- https://github.com/Casecommons/pg_search/pull/201
- https://github.com/Casecommons/pg_search/pull/210

This can happen in case of complex associations and callbacks, when
destroying associated objects results in model.save being called from
after_destroy hook.

Fix and spec for it are provided.