### PR TITLE
Add Rails version to generated migrations

### DIFF
--- a/lib/pg_search/migration/generator.rb
+++ b/lib/pg_search/migration/generator.rb
@@ -1,3 +1,4 @@
+require 'active_record'
 require 'rails/generators/base'
 
 module PgSearch
@@ -13,7 +14,7 @@ module PgSearch
       def create_migration
         now = Time.now.utc
         filename = "#{now.strftime('%Y%m%d%H%M%S')}_#{migration_name}.rb"
-        template "#{migration_name}.rb.erb", "db/migrate/#{filename}"
+        template "#{migration_name}.rb.erb", "db/migrate/#{filename}", migration_version
       end
 
       private
@@ -22,6 +23,14 @@ module PgSearch
         sql_directory = File.expand_path('../../../../sql', __FILE__)
         source_path = File.join(sql_directory, "#{filename}.sql")
         File.read(source_path).strip
+      end
+
+      def migration_version
+        if ActiveRecord::VERSION::MAJOR >= 5
+          "[#{ActiveRecord::VERSION::MAJOR}.#{ActiveRecord::VERSION::MINOR}]"
+        else
+          ""
+        end
       end
     end
   end

--- a/lib/pg_search/migration/templates/add_pg_search_dmetaphone_support_functions.rb.erb
+++ b/lib/pg_search/migration/templates/add_pg_search_dmetaphone_support_functions.rb.erb
@@ -1,4 +1,4 @@
-class AddPgSearchDmetaphoneSupportFunctions < ActiveRecord::Migration
+class AddPgSearchDmetaphoneSupportFunctions < ActiveRecord::Migration<%= migration_version %>
   def self.up
     say_with_time("Adding support functions for pg_search :dmetaphone") do
       execute <<-'SQL'

--- a/lib/pg_search/migration/templates/create_pg_search_documents.rb.erb
+++ b/lib/pg_search/migration/templates/create_pg_search_documents.rb.erb
@@ -1,4 +1,4 @@
-class CreatePgSearchDocuments < ActiveRecord::Migration
+class CreatePgSearchDocuments < ActiveRecord::Migration<%= migration_version %>
   def self.up
     say_with_time("Creating table for pg_search multisearch") do
       create_table :pg_search_documents do |t|


### PR DESCRIPTION
Reported in Casecommons/pg_search/issues/361

Include the Rails major and minor version to the inherited `ActiveRecord::Migration` class, when generating migrations within a Rails app version 5 or greater.

Raises when `ActiveRecord::Migration` is inherited directly:  https://github.com/rails/rails/commit/249f71a22ab21c03915da5606a063d321f04d4d3