### PR TITLE
Limit highlighted attributes when searching against multiple fields

### DIFF
--- a/lib/pg_search/features/feature.rb
+++ b/lib/pg_search/features/feature.rb
@@ -5,7 +5,7 @@ module PgSearch
   module Features
     class Feature
       def self.valid_options
-        %i[only sort_only]
+        %i[only sort_only highlight_only]
       end
 
       delegate :connection, :quoted_table_name, :to => :'@model'
@@ -33,6 +33,20 @@ module PgSearch
           end
         else
           all_columns
+        end
+      end
+
+      def highlight_document
+        highlight_columns.map { |column| column.to_sql }.join(" || ' ' || ")
+      end
+
+      def highlight_columns
+        if options[:highlight_only]
+          columns.select do |column|
+            Array.wrap(options[:highlight_only]).map(&:to_s).include? column.name
+          end
+        else
+          columns
         end
       end
 

--- a/lib/pg_search/features/tsearch.rb
+++ b/lib/pg_search/features/tsearch.rb
@@ -27,7 +27,7 @@ module PgSearch
       def ts_headline
         Arel::Nodes::NamedFunction.new("ts_headline", [
           dictionary,
-          arel_wrap(document),
+          arel_wrap(highlight_document),
           arel_wrap(tsquery),
           Arel::Nodes.build_quoted(ts_headline_options)
         ]).to_sql

--- a/spec/lib/pg_search/features/tsearch_spec.rb
+++ b/spec/lib/pg_search/features/tsearch_spec.rb
@@ -231,6 +231,69 @@ describe PgSearch::Features::TSearch do
 
         expect(highlight_sql).to eq(expected_sql)
       end
+
+      context "when options[:highlight_only] has options set" do
+        it "passes the options to ts_headline" do
+          query = "query"
+          columns = [
+            PgSearch::Configuration::Column.new(:name, nil, Model),
+            PgSearch::Configuration::Column.new(:content, nil, Model)
+          ]
+          options = {
+            highlight: {
+              StartSel: '<start class="search">',
+              StopSel: '<stop>',
+              MaxWords: 123,
+              MinWords: 456,
+              ShortWord: 4,
+              HighlightAll: true,
+              MaxFragments: 3,
+              FragmentDelimiter: '&hellip;'
+            },
+            highlight_only: [:content]
+          }
+
+          config = double(:config, :ignore => [])
+          normalizer = PgSearch::Normalizer.new(config)
+
+          feature = described_class.new(query, options, columns, Model, normalizer)
+
+          expected_sql = %{(ts_headline('simple', (coalesce(#{Model.quoted_table_name}."content"::text, '')), (to_tsquery('simple', ''' ' || 'query' || ' ''')), 'StartSel = "<start class=""search"">", StopSel = "<stop>", MaxFragments = 3, MaxWords = 123, MinWords = 456, ShortWord = 4, FragmentDelimiter = "&hellip;", HighlightAll = TRUE'))}
+
+          expect(feature.highlight.to_sql).to eq(expected_sql)
+        end
+
+        it "passes deprecated options to ts_headline" do
+          query = "query"
+          columns = [
+            PgSearch::Configuration::Column.new(:name, nil, Model),
+            PgSearch::Configuration::Column.new(:content, nil, Model),
+          ]
+          options = {
+            highlight: {
+              start_sel: '<start class="search">',
+              stop_sel: '<stop>',
+              max_words: 123,
+              min_words: 456,
+              short_word: 4,
+              highlight_all: false,
+              max_fragments: 3,
+              fragment_delimiter: '&hellip;'
+            },
+            highlight_only: [:content]
+          }
+
+          config = double(:config, :ignore => [])
+          normalizer = PgSearch::Normalizer.new(config)
+
+          feature = described_class.new(query, options, columns, Model, normalizer)
+
+          highlight_sql = ActiveSupport::Deprecation.silence { feature.highlight.to_sql }
+          expected_sql = %{(ts_headline('simple', (coalesce(#{Model.quoted_table_name}."content"::text, '')), (to_tsquery('simple', ''' ' || 'query' || ' ''')), 'StartSel = "<start class=""search"">", StopSel = "<stop>", MaxFragments = 3, MaxWords = 123, MinWords = 456, ShortWord = 4, FragmentDelimiter = "&hellip;", HighlightAll = FALSE'))}
+
+          expect(highlight_sql).to eq(expected_sql)
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
This is useful when you are searching like this `against: {title: 'A', body: 'B'}` but you want to highlight only `body`

Usage example:
```ruby
pg_search_scope :search,
    against: {title: 'A', body: 'B'}, 
    using: {
      tsearch: { 
        highlight: {
          StartSel: '<start>',
          StopSel: '<stop>',
          MaxWords: 123,
          MinWords: 456,
          ShortWord: 4,
          HighlightAll: true,
          MaxFragments: 3,
          FragmentDelimiter: '&hellip;'
        }, highlight_only: ["body"]
      }
    }
```