### PR TITLE
Fix multisearch rebuild for camel case column names

### DIFF
--- a/lib/pg_search/multisearch/rebuilder.rb
+++ b/lib/pg_search/multisearch/rebuilder.rb
@@ -74,7 +74,7 @@ module PgSearch
       end
 
       def content_expressions
-        columns.map { |column| %{coalesce(:model_table.#{column}::text, '')} }.join(" || ' ' || ")
+        columns.map { |column| %{coalesce(:model_table.\"#{column}\"::text, '')} }.join(" || ' ' || ")
       end
 
       def columns

--- a/spec/lib/pg_search/multisearch/rebuilder_spec.rb
+++ b/spec/lib/pg_search/multisearch/rebuilder_spec.rb
@@ -112,7 +112,7 @@ describe PgSearch::Multisearch::Rebuilder do
               SELECT 'Model' AS searchable_type,
                      #{Model.quoted_table_name}.#{Model.primary_key} AS searchable_id,
                      (
-                       coalesce(#{Model.quoted_table_name}.name::text, '')
+                       coalesce(#{Model.quoted_table_name}."name"::text, '')
                      ) AS content,
                      '#{expected_timestamp}' AS created_at,
                      '#{expected_timestamp}' AS updated_at
@@ -157,7 +157,7 @@ describe PgSearch::Multisearch::Rebuilder do
                 SELECT 'ModelWithNonStandardPrimaryKey' AS searchable_type,
                        #{ModelWithNonStandardPrimaryKey.quoted_table_name}.non_standard_primary_key AS searchable_id,
                        (
-                         coalesce(#{ModelWithNonStandardPrimaryKey.quoted_table_name}.name::text, '')
+                         coalesce(#{ModelWithNonStandardPrimaryKey.quoted_table_name}."name"::text, '')
                        ) AS content,
                        '#{expected_timestamp}' AS created_at,
                        '#{expected_timestamp}' AS updated_at

--- a/spec/lib/pg_search/multisearch_spec.rb
+++ b/spec/lib/pg_search/multisearch_spec.rb
@@ -121,7 +121,7 @@ describe PgSearch::Multisearch do
               SELECT #{connection.quote(model.name)} AS searchable_type,
                      #{model.quoted_table_name}.id AS searchable_id,
                      (
-                       coalesce(#{model.quoted_table_name}.title::text, '')
+                       coalesce(#{model.quoted_table_name}."title"::text, '')
                      ) AS content,
                      #{connection.quote(connection.quoted_date(now))} AS created_at,
                      #{connection.quote(connection.quoted_date(now))} AS updated_at
@@ -148,7 +148,7 @@ describe PgSearch::Multisearch do
               SELECT #{connection.quote(model.name)} AS searchable_type,
                      #{model.quoted_table_name}.id AS searchable_id,
                      (
-                       coalesce(#{model.quoted_table_name}.title::text, '') || ' ' || coalesce(#{model.quoted_table_name}.content::text, '')
+                       coalesce(#{model.quoted_table_name}."title"::text, '') || ' ' || coalesce(#{model.quoted_table_name}."content"::text, '')
                      ) AS content,
                      #{connection.quote(connection.quoted_date(now))} AS created_at,
                      #{connection.quote(connection.quoted_date(now))} AS updated_at


### PR DESCRIPTION
Multisearch rebuild queries are broken when column names are camel cased.  Use quote escaping in queries to resolve.  Safe to do this for non camel cased column names as well, so just always do it.