### PR TITLE
Add failing spec for invalid tsquery generation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,10 +42,12 @@ matrix:
       env: ACTIVE_RECORD_VERSION="~> 5.0.0"
 
 before_script:
+  - "psql --version"
   - "psql -c 'create database pg_search_test;' -U postgres >/dev/null"
 
 script: "bin/rake"
 
 addons:
+  postgresql: "9.6"
   code_climate:
     repo_token: 0a0e3e45118bc447e677d52c21d056a5471c4921d54f96ed7b2550d9fc5043ea

--- a/lib/pg_search/features/tsearch.rb
+++ b/lib/pg_search/features/tsearch.rb
@@ -93,7 +93,7 @@ module PgSearch
         end
       end
 
-      DISALLOWED_TSQUERY_CHARACTERS = /['?\\:]/
+      DISALLOWED_TSQUERY_CHARACTERS = /['?\\:‘’]/
 
       def tsquery_for_term(unsanitized_term) # rubocop:disable Metrics/AbcSize
         if options[:negation] && unsanitized_term.start_with?("!")

--- a/spec/integration/pg_search_spec.rb
+++ b/spec/integration/pg_search_spec.rb
@@ -1130,6 +1130,15 @@ describe "an Active Record model which includes PgSearch" do
         results = ModelWithPgSearch.search_title_without_accents("abcd\303\251f")
         expect(results).to eq([included])
       end
+
+      context "when the query includes accents" do
+        it "does not create an erroneous tsquery expression" do
+          included = ModelWithPgSearch.create!(:title => "Weird L‘Content")
+
+          results = ModelWithPgSearch.search_title_without_accents("L‘Content")
+          expect(results).to eq([included])
+        end
+      end
     end
 
     context "when passed a :ranked_by expression" do


### PR DESCRIPTION
This is a failing test for a bug we ran into: when searching on an unaccented pg_search_scope for a query which includes `‘`, an invalid expression is generated:

```
     ActiveRecord::StatementInvalid:
       PG::SyntaxError: ERROR:  syntax error in tsquery: "' L'Content '"
       : SELECT "with_model_model_with_pg_searches_57799_70174002903340".* FROM "with_model_model_with_pg_searches_57799_70174002903340" INNER JOIN (SELECT "with_model_model_with_pg_searches_57799_70174002903340"."id" AS pg_search_id, (ts_rank((to_tsvector('simple', unaccent(coalesce("with_model_model_with_pg_searches_57799_70174002903340"."title"::text, '')))), (to_tsquery('simple', ''' ' || unaccent('L‘Content') || ' ''')), 0)) AS rank FROM "with_model_model_with_pg_searches_57799_70174002903340" WHERE (((to_tsvector('simple', unaccent(coalesce("with_model_model_with_pg_searches_57799_70174002903340"."title"::text, '')))) @@ (to_tsquery('simple', ''' ' || unaccent('L‘Content') || ' '''))))) AS pg_search_03f80d9a6ae537cac323d6 ON "with_model_model_with_pg_searches_57799_70174002903340"."id" = pg_search_03f80d9a6ae537cac323d6.pg_search_id ORDER BY pg_search_03f80d9a6ae537cac323d6.rank DESC, "with_model_model_with_pg_searches_57799_70174002903340"."id" ASC
```

It wasn't immediately obvious to me how to fix this (I had a look at `normalizer.rb`) so I'm posting this here, maybe it's an easy fix for you, or you can give me a hint where to look. In case it's important, the project where this happened is running on Rails 4.2.