### PR TITLE
Performing where query on results instead of joining two full table scans for simple pg_search_scopes

### DIFF
--- a/lib/pg_search/scope_options.rb
+++ b/lib/pg_search/scope_options.rb
@@ -12,14 +12,11 @@ module PgSearch
 
     def apply(scope)
       scope = include_table_aliasing_for_rank(scope)
-      rank_table_alias = scope.pg_search_rank_table_alias(:include_counter)
-
-      scope
-        .joins(rank_join(rank_table_alias))
-        .order(Arel.sql("#{rank_table_alias}.rank DESC, #{order_within_rank}"))
-        .extend(DisableEagerLoading)
-        .extend(WithPgSearchRank)
-        .extend(WithPgSearchHighlight[feature_for(:tsearch)])
+      if config.associations.any?
+        apply_with_inner_join(scope)
+      else
+        apply_without_inner_join(scope)
+      end
     end
 
     # workaround for https://github.com/Casecommons/pg_search/issues/14
@@ -61,6 +58,39 @@ module PgSearch
         scope = scope.select("#{table_name}.*") unless scope.select_values.any?
         scope.select("#{pg_search_rank_table_alias}.rank AS pg_search_rank")
       end
+
+      def where_pg_search_rank(value)
+        scope = self
+        scope.where("#{PgSearch::Configuration.alias(table_name)}.rank#{value}")
+      end
+    end
+
+    module WithPgSearchRankNoInnerJoin
+      def self.[](rank_value)
+        Module.new do
+          include WithPgSearchRankNoInnerJoin
+          define_method(:rank_value) { rank_value }
+        end
+      end
+
+      def rank_field
+        "#{rank_value} AS pg_search_rank"
+      end
+
+      def rank_value
+        raise TypeError.new("You need to instantiate this module with []")
+      end
+
+      def with_pg_search_rank
+        scope = self
+        scope = scope.select("#{table_name}.*") unless scope.select_values.any?
+        scope.select(rank_field)
+      end
+
+      def where_pg_search_rank(value)
+        scope = self
+        scope.where("#{rank_value}#{value}")
+      end
     end
 
     module PgSearchRankTableAliasing
@@ -92,6 +122,26 @@ module PgSearch
     private
 
     delegate :connection, :quoted_table_name, :to => :model
+
+    def apply_with_inner_join(scope)
+      rank_table_alias = scope.pg_search_rank_table_alias(:include_counter)
+
+      scope
+        .joins(rank_join(rank_table_alias))
+        .order(Arel.sql("#{rank_table_alias}.rank DESC, #{order_within_rank}"))
+        .extend(DisableEagerLoading)
+        .extend(WithPgSearchRank)
+        .extend(WithPgSearchHighlight[feature_for(:tsearch)])
+    end
+
+    def apply_without_inner_join(scope)
+      scope
+        .where(conditions)
+        .order("#{rank_order}, #{order_within_rank}")
+        .extend(DisableEagerLoading)
+        .extend(WithPgSearchRankNoInnerJoin[rank])
+        .extend(WithPgSearchHighlight[feature_for(:tsearch)])
+    end
 
     def subquery
       model
@@ -169,10 +219,17 @@ module PgSearch
       "INNER JOIN (#{subquery.to_sql}) AS #{rank_table_alias} ON #{primary_key} = #{rank_table_alias}.pg_search_id"
     end
 
+    def rank_order
+      "#{rank} DESC"
+    end
+
     def include_table_aliasing_for_rank(scope)
-      return scope if scope.included_modules.include?(PgSearchRankTableAliasing)
-      scope.all.spawn.tap do |new_scope|
-        new_scope.class_eval { include PgSearchRankTableAliasing }
+      if scope.included_modules.include?(PgSearchRankTableAliasing)
+        scope
+      else
+        (::ActiveRecord::VERSION::MAJOR < 4 ? scope.scoped : scope.all.spawn).tap do |new_scope|
+          new_scope.class_eval { include PgSearchRankTableAliasing }
+        end
       end
     end
   end

--- a/spec/integration/pg_search_spec.rb
+++ b/spec/integration/pg_search_spec.rb
@@ -342,7 +342,7 @@ describe "an Active Record model which includes PgSearch" do
         twice = ModelWithPgSearch.create!(:content => 'foo foo')
 
         records = ModelWithPgSearch.search_content('foo')
-                  .where("#{PgSearch::Configuration.alias(ModelWithPgSearch.table_name)}.rank > 0.07")
+                      .where_pg_search_rank(' > 0.07')
 
         expect(records).to eq [twice]
       end


### PR DESCRIPTION
I was working on improving pg_search_scope running on a database table with 3 million rows and the time to run the pg_search_scope search along with another scope on the same model was taking 7 seconds.
By implementing the changes that @LeonidMorozov submitted previously we saw this query drop to sub 1 second.

It would be great to get feedback from the maintainers to see what their thoughts are on this approach.