### PR TITLE
Remove outdated instructions about the tsvector column type

### DIFF
--- a/README.md
+++ b/README.md
@@ -940,13 +940,6 @@ To use this functionality you'll need to do a few things:
                       trigram: {} # trigram does not use tsvectors
                     }
     ```
-*   You cannot dump a `tsvector` column to `schema.rb`. Instead, you need to switch to using the native PostgreSQL SQL format schema dump.
-    In your `config/application.rb` you should set
-
-        config.active_record.schema_format = :sql
-        
-    Read more about it here: http://guides.rubyonrails.org/migrations.html#types-of-schema-dumps
-
 
 Please note that the :against column is only used when the tsvector_column is
 not present for the search type.


### PR DESCRIPTION
The `tsvector` column [is a supported type](https://github.com/rails/rails/blob/4-2-stable/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb#L100) in ActiveRecord 4.2+, so the instructions that require the reader to change the schema format to SQL are incorrect. You can still use the `schema.rb` file when your PostgreSQL database contains a column of type `tsvector`.