### PR TITLE
docs: enhance documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,12 +89,12 @@ multisearchable in its class definition.
 ```ruby
 class EpicPoem < ActiveRecord::Base
   include PgSearch
-  multisearchable :against => [:title, :author]
+  multisearchable against: [:title, :author]
 end
 
 class Flower < ActiveRecord::Base
   include PgSearch
-  multisearchable :against => :color
+  multisearchable against: :color
 end
 ```
 
@@ -114,14 +114,14 @@ particular record should be included.
 ```ruby
 class Convertible < ActiveRecord::Base
   include PgSearch
-  multisearchable :against => [:make, :model],
-                  :if => :available_in_red?
+  multisearchable against: [:make, :model],
+                  if: :available_in_red?
 end
 
 class Jalopy < ActiveRecord::Base
   include PgSearch
-  multisearchable :against => [:make, :model],
-                  :if => lambda { |record| record.model_year > 1970 }
+  multisearchable against: [:make, :model],
+                  if: lambda { |record| record.model_year > 1970 }
 end
 ```
 
@@ -134,8 +134,8 @@ timestamp.
 ```ruby
 class AntipatternExample
   include PgSearch
-  multisearchable :against => [:contents],
-                  :if => :published?
+  multisearchable against: [:contents],
+                  if: :published?
 
   def published?
     published_at < Time.now
@@ -143,8 +143,8 @@ class AntipatternExample
 end
 
 problematic_record = AntipatternExample.create!(
-  :contents => "Using :if with a timestamp",
-  :published_at => 10.minutes.from_now
+  contents: "Using :if with a timestamp",
+  published_at: 10.minutes.from_now
 )
 
 problematic_record.published?     # => false
@@ -184,7 +184,7 @@ First, we need to add `author_id` to the migration creating our pg_search_docume
   create_table :pg_search_documents do |t|
         t.text :content
         t.integer :author_id
-        t.belongs_to :searchable, :polymorphic => true, :index => true
+        t.belongs_to :searchable, polymorphic: true, index: true
 ```
 
 Then, we can send in this additional attribute in a lambda
@@ -209,7 +209,7 @@ record, and on the PgSearch::Document record there is a belongs_to :searchable
 polymorphic association pointing back to the original record.
 
 ```ruby
-odyssey = EpicPoem.create!(:title => "Odyssey", :author => "Homer")
+odyssey = EpicPoem.create!(title: "Odyssey", author: "Homer")
 search_document = odyssey.pg_search_document #=> PgSearch::Document instance
 search_document.searchable #=> #<EpicPoem id: 1, title: "Odyssey", author: "Homer">
 ```
@@ -220,8 +220,8 @@ To fetch the PgSearch::Document entries for all of the records that match a
 given query, use PgSearch.multisearch.
 
 ```ruby
-odyssey = EpicPoem.create!(:title => "Odyssey", :author => "Homer")
-rose = Flower.create!(:color => "Red")
+odyssey = EpicPoem.create!(title: "Odyssey", author: "Homer")
+rose = Flower.create!(color: "Red")
 PgSearch.multisearch("Homer") #=> [#<PgSearch::Document searchable: odyssey>]
 PgSearch.multisearch("Red") #=> [#<PgSearch::Document searchable: rose>]
 ```
@@ -235,7 +235,7 @@ receive SQL requests when necessary.
 
 ```ruby
 PgSearch.multisearch("Bertha").limit(10)
-PgSearch.multisearch("Juggler").where(:searchable_type => "Occupation")
+PgSearch.multisearch("Juggler").where(searchable_type: "Occupation")
 PgSearch.multisearch("Alamo").page(3).per(30)
 PgSearch.multisearch("Diagonal").find_each do |document|
   puts document.searchable.updated_at
@@ -252,8 +252,8 @@ PgSearch.multisearch_options in an initializer:
 
 ```ruby
 PgSearch.multisearch_options = {
-  :using => [:tsearch, :trigram],
-  :ignoring => :accents
+  using: [:tsearch, :trigram],
+  ignoring: :accents
 }
 ```
 
@@ -274,7 +274,7 @@ To remove all of the documents for a given class, you can simply delete all of
 the PgSearch::Document records.
 
 ```ruby
-PgSearch::Document.delete_all(:searchable_type => "Animal")
+PgSearch::Document.delete_all(searchable_type: "Animal")
 ```
 
 To regenerate the documents for a given class, run:
@@ -310,7 +310,7 @@ the pg_search_documents table all at once. However, if you call any dynamic
 methods in :against, the following strategy will be used:
 
 ```ruby
-PgSearch::Document.delete_all(:searchable_type => "Ingredient")
+PgSearch::Document.delete_all(searchable_type: "Ingredient")
 Ingredient.find_each { |record| record.update_pg_search_document }
 ```
 
@@ -376,7 +376,7 @@ To search against a column, pass a symbol as the :against option.
 ```ruby
 class BlogPost < ActiveRecord::Base
   include PgSearch
-  pg_search_scope :search_by_title, :against => :title
+  pg_search_scope :search_by_title, against: :title
 end
 ```
 
@@ -384,8 +384,8 @@ We now have an ActiveRecord scope named search_by_title on our BlogPost model.
 It takes one parameter, a search query string.
 
 ```ruby
-BlogPost.create!(:title => "Recent Developments in the World of Pastrami")
-BlogPost.create!(:title => "Prosciutto and You: A Retrospective")
+BlogPost.create!(title: "Recent Developments in the World of Pastrami")
+BlogPost.create!(title: "Prosciutto and You: A Retrospective")
 BlogPost.search_by_title("pastrami") # => [#<BlogPost id: 2, title: "Recent Developments in the World of Pastrami">]
 ```
 
@@ -396,15 +396,15 @@ Just pass an Array if you'd like to search more than one column.
 ```ruby
 class Person < ActiveRecord::Base
   include PgSearch
-  pg_search_scope :search_by_full_name, :against => [:first_name, :last_name]
+  pg_search_scope :search_by_full_name, against: [:first_name, :last_name]
 end
 ```
 
 Now our search query can match either or both of the columns.
 
 ```ruby
-person_1 = Person.create!(:first_name => "Grant", :last_name => "Hill")
-person_2 = Person.create!(:first_name => "Hugh", :last_name => "Grant")
+person_1 = Person.create!(first_name: "Grant", last_name: "Hill")
+person_2 = Person.create!(first_name: "Hugh", last_name: "Grant")
 
 Person.search_by_full_name("Grant") # => [person_1, person_2]
 Person.search_by_full_name("Grant Hill") # => [person_1]
@@ -426,14 +426,14 @@ class Person < ActiveRecord::Base
   pg_search_scope :search_by_name, lambda { |name_part, query|
     raise ArgumentError unless [:first, :last].include?(name_part)
     {
-      :against => name_part,
-      :query => query
+      against: name_part,
+      query: query
     }
   }
 end
 
-person_1 = Person.create!(:first_name => "Grant", :last_name => "Hill")
-person_2 = Person.create!(:first_name => "Hugh", :last_name => "Grant")
+person_1 = Person.create!(first_name: "Grant", last_name: "Hill")
+person_2 = Person.create!(first_name: "Hugh", last_name: "Grant")
 
 Person.search_by_name :first, "Grant" # => [person_1]
 Person.search_by_name :last, "Grant" # => [person_2]
@@ -463,11 +463,11 @@ class Salami < ActiveRecord::Base
   include PgSearch
 
   belongs_to :cracker
-  has_many :cheeses, :through => :cracker
+  has_many :cheeses, through: :cracker
 
-  pg_search_scope :tasty_search, :associated_against => {
-    :cheeses => [:kind, :brand],
-    :cracker => :kind
+  pg_search_scope :tasty_search, associated_against: {
+    cheeses: [:kind, :brand],
+    cracker: :kind
   }
 end
 
@@ -475,13 +475,13 @@ salami_1 = Salami.create!
 salami_2 = Salami.create!
 salami_3 = Salami.create!
 
-limburger = Cheese.create!(:kind => "Limburger")
-brie = Cheese.create!(:kind => "Brie")
-pepper_jack = Cheese.create!(:kind => "Pepper Jack")
+limburger = Cheese.create!(kind: "Limburger")
+brie = Cheese.create!(kind: "Brie")
+pepper_jack = Cheese.create!(kind: "Pepper Jack")
 
-Cracker.create!(:kind => "Black Pepper", :cheeses => [brie], :salami => salami_1)
-Cracker.create!(:kind => "Ritz", :cheeses => [limburger, pepper_jack], :salami => salami_2)
-Cracker.create!(:kind => "Graham", :cheeses => [limburger], :salami => salami_3)
+Cracker.create!(kind: "Black Pepper", cheeses: [brie], salami: salami_1)
+Cracker.create!(kind: "Ritz", cheeses: [limburger, pepper_jack], salami: salami_2)
+Cracker.create!(kind: "Graham", cheeses: [limburger], salami: salami_3)
 
 Salami.tasty_search("pepper") # => [salami_1, salami_2]
 ```
@@ -496,7 +496,7 @@ search techniques.
 ```ruby
 class Beer < ActiveRecord::Base
   include PgSearch
-  pg_search_scope :search_name, :against => :name, :using => [:tsearch, :trigram, :dmetaphone]
+  pg_search_scope :search_name, against: :name, using: [:tsearch, :trigram, :dmetaphone]
 end
 ```
 
@@ -522,10 +522,10 @@ subtitle, and finally the content.
 ```ruby
 class NewsArticle < ActiveRecord::Base
   include PgSearch
-  pg_search_scope :search_full_text, :against => {
-    :title => 'A',
-    :subtitle => 'B',
-    :content => 'C'
+  pg_search_scope :search_full_text, against: {
+    title: 'A',
+    subtitle: 'B',
+    content: 'C'
   }
 end
 ```
@@ -537,7 +537,7 @@ weight. If you omit the weight, a default will be used.
 ```ruby
 class NewsArticle < ActiveRecord::Base
   include PgSearch
-  pg_search_scope :search_full_text, :against => [
+  pg_search_scope :search_full_text, against: [
     [:title, 'A'],
     [:subtitle, 'B'],
     [:content, 'C']
@@ -546,9 +546,9 @@ end
 
 class NewsArticle < ActiveRecord::Base
   include PgSearch
-  pg_search_scope :search_full_text, :against => [
+  pg_search_scope :search_full_text, against: [
     [:title, 'A'],
-    {:subtitle => 'B'},
+    {subtitle: 'B'},
     :content
   ]
 end
@@ -565,15 +565,15 @@ shown in the following example.
 class Superhero < ActiveRecord::Base
   include PgSearch
   pg_search_scope :whose_name_starts_with,
-                  :against => :name,
-                  :using => {
-                    :tsearch => {:prefix => true}
+                  against: :name,
+                  using: {
+                    tsearch: { prefix: true }
                   }
 end
 
-batman = Superhero.create :name => 'Batman'
-batgirl = Superhero.create :name => 'Batgirl'
-robin = Superhero.create :name => 'Robin'
+batman = Superhero.create name: 'Batman'
+batgirl = Superhero.create name: 'Batgirl'
+robin = Superhero.create name: 'Robin'
 
 Superhero.whose_name_starts_with("Bat") # => [batman, batgirl]
 ```
@@ -594,16 +594,16 @@ term that you were trying to exclude.
 class Animal < ActiveRecord::Base
   include PgSearch
   pg_search_scope :with_name_matching,
-                  :against => :name,
-                  :using => {
-                    :tsearch => {:negation => true}
+                  against: :name,
+                  using: {
+                    tsearch: {negation: true}
                   }
 end
 
-one_fish = Animal.create(:name => "one fish")
-two_fish = Animal.create(:name => "two fish")
-red_fish = Animal.create(:name => "red fish")
-blue_fish = Animal.create(:name => "blue fish")
+one_fish = Animal.create(name: "one fish")
+two_fish = Animal.create(name: "two fish")
+red_fish = Animal.create(name: "red fish")
+blue_fish = Animal.create(name: "blue fish")
 
 Animal.with_name_matching("fish !red !blue") # => [one_fish, two_fish]
 ```
@@ -623,20 +623,20 @@ dictionary will be used.
 class BoringTweet < ActiveRecord::Base
   include PgSearch
   pg_search_scope :kinda_matching,
-                  :against => :text,
-                  :using => {
-                    :tsearch => {:dictionary => "english"}
+                  against: :text,
+                  using: {
+                    tsearch: {dictionary: "english"}
                   }
   pg_search_scope :literally_matching,
-                  :against => :text,
-                  :using => {
-                    :tsearch => {:dictionary => "simple"}
+                  against: :text,
+                  using: {
+                    tsearch: {dictionary: "simple"}
                   }
 end
 
-sleepy = BoringTweet.create! :text => "I snoozed my alarm for fourteen hours today. I bet I can beat that tomorrow! #sleepy"
-sleeping = BoringTweet.create! :text => "You know what I like? Sleeping. That's what. #enjoyment"
-sleeper = BoringTweet.create! :text => "Have you seen Woody Allen's movie entitled Sleeper? Me neither. #boycott"
+sleepy = BoringTweet.create! text: "I snoozed my alarm for fourteen hours today. I bet I can beat that tomorrow! #sleepy"
+sleeping = BoringTweet.create! text: "You know what I like? Sleeping. That's what. #enjoyment"
+sleeper = BoringTweet.create! text: "Have you seen Woody Allen's movie entitled Sleeper? Me neither. #boycott"
 
 BoringTweet.kinda_matching("sleeping") # => [sleepy, sleeping, sleeper]
 BoringTweet.literally_matching("sleeping") # => [sleeping]
@@ -667,16 +667,16 @@ their numbers together.
 class BigLongDocument < ActiveRecord::Base
   include PgSearch
   pg_search_scope :regular_search,
-                  :against => :text
+                  against: :text
 
   pg_search_scope :short_search,
-                  :against => :text,
-                  :using => {
-                    :tsearch => {:normalization => 2}
+                  against: :text,
+                  using: {
+                    tsearch: {normalization: 2}
                   }
 
-long = BigLongDocument.create!(:text => "Four score and twenty years ago")
-short = BigLongDocument.create!(:text => "Four score")
+long = BigLongDocument.create!(text: "Four score and twenty years ago")
+short = BigLongDocument.create!(text: "Four score")
 
 BigLongDocument.regular_search("four score") #=> [long, short]
 BigLongDocument.short_search("four score") #=> [short, long]
@@ -691,18 +691,18 @@ models containing any word in the search terms.
 class Number < ActiveRecord::Base
   include PgSearch
   pg_search_scope :search_any_word,
-                  :against => :text,
-                  :using => {
-                    :tsearch => {:any_word => true}
+                  against: :text,
+                  using: {
+                    tsearch: {any_word: true}
                   }
 
   pg_search_scope :search_all_words,
-                  :against => :text
+                  against: :text
 end
 
-one = Number.create! :text => 'one'
-two = Number.create! :text => 'two'
-three = Number.create! :text => 'three'
+one = Number.create! text: 'one'
+two = Number.create! text: 'two'
+three = Number.create! text: 'three'
 
 Number.search_any_word('one two three') # => [one, two, three]
 Number.search_all_words('one two three') # => []
@@ -717,17 +717,17 @@ but will not include it in the query's WHERE condition.
 class Person < ActiveRecord::Base
   include PgSearch
   pg_search_scope :search,
-                  :against => :name,
-                  :using => {
-                    :tsearch => {:any_word => true}
-                    :dmetaphone => {:any_word => true, :sort_only => true}
+                  against: :name,
+                  using: {
+                    tsearch: {any_word: true}
+                    dmetaphone: {any_word: true, sort_only: true}
                   }
 end
 
-exact = Person.create!(:name => 'ash hines')
-one_exact_one_close = Person.create!(:name => 'ash heinz')
-one_exact = Person.create!(:name => 'ash smith')
-one_close = Person.create!(:name => 'leigh heinz')
+exact = Person.create!(name: 'ash hines')
+one_exact_one_close = Person.create!(name: 'ash heinz')
+one_exact = Person.create!(name: 'ash smith')
+one_close = Person.create!(name: 'leigh heinz')
 
 Person.search('ash hines') # => [exact, one_exact_one_close, one_exact]
 ```
@@ -746,8 +746,8 @@ class Person < ActiveRecord::Base
                   using: {
                     tsearch: {
                       highlight: {
-                        StartSel: '<start>',
-                        StopSel: '<stop>',
+                        StartSel: '<b>',
+                        StopSel: '</b>',
                         MaxWords: 123,
                         MinWords: 456,
                         ShortWord: 4,
@@ -796,14 +796,14 @@ The following example shows how to use :dmetaphone.
 class Word < ActiveRecord::Base
   include PgSearch
   pg_search_scope :that_sounds_like,
-                  :against => :spelling,
-                  :using => :dmetaphone
+                  against: :spelling,
+                  using: :dmetaphone
 end
 
-four = Word.create! :spelling => 'four'
-far = Word.create! :spelling => 'far'
-fur = Word.create! :spelling => 'fur'
-five = Word.create! :spelling => 'five'
+four = Word.create! spelling: 'four'
+far = Word.create! spelling: 'far'
+fur = Word.create! spelling: 'fur'
+five = Word.create! spelling: 'five'
 
 Word.that_sounds_like("fir") # => [four, far, fur]
 ```
@@ -827,14 +827,14 @@ feature can be used.
 class Website < ActiveRecord::Base
   include PgSearch
   pg_search_scope :kinda_spelled_like,
-                  :against => :name,
-                  :using => :trigram
+                  against: :name,
+                  using: :trigram
 end
 
-yahooo = Website.create! :name => "Yahooo!"
-yohoo = Website.create! :name => "Yohoo!"
-gogle = Website.create! :name => "Gogle"
-facebook = Website.create! :name => "Facebook"
+yahooo = Website.create! name: "Yahooo!"
+yohoo = Website.create! name: "Yohoo!"
+gogle = Website.create! name: "Gogle"
+facebook = Website.create! name: "Facebook"
 
 Website.kinda_spelled_like("Yahoo!") # => [yahooo, yohoo]
 ```
@@ -853,23 +853,23 @@ class Vegetable < ActiveRecord::Base
   include PgSearch
 
   pg_search_scope :strictly_spelled_like,
-                  :against => :name,
-                  :using => {
-                    :trigram => {
-                      :threshold => 0.5
+                  against: :name,
+                  using: {
+                    trigram: {
+                      threshold: 0.5
                     }
                   }
 
   pg_search_scope :roughly_spelled_like,
-                  :against => :name,
-                  :using => {
-                    :trigram => {
-                      :threshold => 0.1
+                  against: :name,
+                  using: {
+                    trigram: {
+                      threshold: 0.1
                     }
                   }
 end
 
-cauliflower = Vegetable.create! :name => "cauliflower"
+cauliflower = Vegetable.create! name: "cauliflower"
 
 Vegetable.roughly_spelled_like("couliflower") # => [cauliflower]
 Vegetable.strictly_spelled_like("couliflower") # => [cauliflower]
@@ -891,11 +891,11 @@ class Image < ActiveRecord::Base
   include PgSearch
 
   pg_search_scope :combined_search,
-                  :against => [:file_name, :short_description, :long_description]
-                  :using => {
-                    :tsearch => { :dictionary  => 'english' },
-                    :trigram => {
-                      :only => [:file_name, :short_description]
+                  against: [:file_name, :short_description, :long_description]
+                  using: {
+                    tsearch: { dictionary: 'english' },
+                    trigram: {
+                      only: [:file_name, :short_description]
                     }
                   }
 
@@ -925,13 +925,13 @@ must be installed before this feature can be used.
 class SpanishQuestion < ActiveRecord::Base
   include PgSearch
   pg_search_scope :gringo_search,
-                  :against => :word,
-                  :ignoring => :accents
+                  against: :word,
+                  ignoring: :accents
 end
 
-what = SpanishQuestion.create(:word => "Qué")
-how_many = SpanishQuestion.create(:word => "Cuánto")
-how = SpanishQuestion.create(:word => "Cómo")
+what = SpanishQuestion.create(word: "Qué")
+how_many = SpanishQuestion.create(word: "Cuánto")
+how = SpanishQuestion.create(word: "Cómo")
 
 SpanishQuestion.gringo_search("Que") # => [what]
 SpanishQuestion.gringo_search("Cüåñtô") # => [how_many]
@@ -968,8 +968,8 @@ To use this functionality you'll need to do a few things:
 
     ```ruby
     pg_search_scope :fast_content_search,
-                    :against => :content,
-                    :using => {
+                    against: :content,
+                    using: {
                       dmetaphone: {
                         tsvector_column: 'tsvector_content_dmetaphone'
                       },
@@ -990,26 +990,26 @@ It's possible to search against more than one tsvector at a time. This could be 
 
 ```ruby
 pg_search_scope :search_title,
-                :against => :title,
-                :using => {
-                  :tsearch => {
-                    :tsvector_column => "title_tsvector"
+                against: :title,
+                using: {
+                  tsearch: {
+                    tsvector_column: "title_tsvector"
                   }
                 }
 
 pg_search_scope :search_body,
-                :against => :body,
-                :using => {
-                  :tsearch => {
-                    :tsvector_column => "body_tsvector"
+                against: :body,
+                using: {
+                  tsearch: {
+                    tsvector_column: "body_tsvector"
                   }
                 }
 
 pg_search_scope :search_title_and_body,
-                :against => [:title, :body],
-                :using => {
-                  :tsearch => {
-                    :tsvector_column => ["title_tsvector", "body_tsvector"]
+                against: [:title, :body],
+                using: {
+                  tsearch: {
+                    tsvector_column: ["title_tsvector", "body_tsvector"]
                   }
                 }
 ```
@@ -1024,9 +1024,9 @@ can pass a :ranked_by option to pg_search_scope.
 
 ```ruby
 pg_search_scope :search_by_tsearch_but_rank_by_trigram,
-                :against => :title,
-                :using => [:tsearch],
-                :ranked_by => ":trigram"
+                against: :title,
+                using: [:tsearch],
+                ranked_by: ":trigram"
 ```
 
 Note that :ranked_by using a String to represent the ranking expression. This
@@ -1036,10 +1036,10 @@ expressions.
 
 ```ruby
 # Weighted ranking to balance multiple approaches
-:ranked_by => ":dmetaphone + (0.25 * :trigram)"
+ranked_by: ":dmetaphone + (0.25 * :trigram)"
 
 # A more complex example, where books.num_pages is an integer column in the table itself
-:ranked_by => "(books.num_pages * :trigram) + (:tsearch / 2.0)"
+ranked_by: "(books.num_pages * :trigram) + (:tsearch / 2.0)"
 ```
 
 #### :order_within_rank (Breaking ties)
@@ -1071,8 +1071,8 @@ descending by updated_at, to rank the most recently updated records first.
 
 ```ruby
 pg_search_scope :search_and_break_ties_by_latest_update,
-                :against => [:title, :content],
-                :order_within_rank => "blog_posts.updated_at DESC"
+                against: [:title, :content],
+                order_within_rank: "blog_posts.updated_at DESC"
 ```
 
 #### PgSearch#pg_search_rank (Reading a record's rank as a Float)


### PR DESCRIPTION
- changed hash syntax (https://github.com/github/rubocop-github/blob/master/STYLEGUIDE.md#hashes)
- in highlight section changed `<start>` and `<stop>` tag to `<b>` and `</b>` to match an example bellow this section (https://github.com/Casecommons/pg_search/pull/402/files#diff-04c6e90faac2675aa89e2176d2eec7d8R749)