### PR TITLE
CI: Use JRuby 9.2.7.0, drop unused sudo: false

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 language: ruby
-sudo: false
 bundler_args: --binstubs
 cache: bundler
 
@@ -7,7 +6,7 @@ rvm:
   - 2.6.3
   - 2.5.5
   - 2.4.6
-  - jruby-9.2.6.0
+  - jruby-9.2.7.0
 
 env:
   global:
@@ -29,7 +28,7 @@ matrix:
   exclude:
     - rvm: 2.4.6
       env: ACTIVE_RECORD_BRANCH="master"
-    - rvm: jruby-9.2.6.0
+    - rvm: jruby-9.2.7.0
       env: ACTIVE_RECORD_VERSION="~> 4.2.9"
     - rvm: 2.4.5
       env: ACTIVE_RECORD_VERSION="~> 6.0.0.beta1"


### PR DESCRIPTION
This PR updates the CI matrix to use latest JRuby, **9.2.7.0**.

[JRuby 9.2.7.0 release blog post](https://www.jruby.org/2019/04/09/jruby-9-2-7-0.html)

- The Travis setting `sudo: false` has been removed - See https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration