### PR TITLE
Speed improvements adding filters in subquery

### DIFF
--- a/lib/pg_search/configuration.rb
+++ b/lib/pg_search/configuration.rb
@@ -59,6 +59,10 @@ module PgSearch
       options[:ranked_by]
     end
 
+    def subquery_condition
+      options[:subquery_condition]
+    end
+
     def features
       Array(options[:using])
     end
@@ -84,7 +88,7 @@ module PgSearch
     end
 
     VALID_KEYS = %w[
-      against ranked_by ignoring using query associated_against order_within_rank
+      against ranked_by ignoring using query associated_against order_within_rank subquery_condition
     ].map(&:to_sym)
 
     VALID_VALUES = {

--- a/lib/pg_search/model.rb
+++ b/lib/pg_search/model.rb
@@ -15,7 +15,14 @@ module PgSearch
                        end
 
         define_singleton_method(name) do |*args|
-          config = Configuration.new(options_proc.call(*args), self)
+          custom_options = {}
+          if args.first.kind_of?(Array)
+            custom_options = options_proc.call(args[0][0])
+            custom_options = custom_options.merge(args[0][1])
+          else
+            custom_options = options_proc.call(*args)
+          end
+          config = Configuration.new(custom_options, self)
           scope_options = ScopeOptions.new(config)
           scope_options.apply(self)
         end

--- a/lib/pg_search/scope_options.rb
+++ b/lib/pg_search/scope_options.rb
@@ -88,6 +88,7 @@ module PgSearch
         .select("#{rank} AS rank")
         .joins(subquery_join)
         .where(conditions)
+        .where(config.subquery_condition)
         .limit(nil)
         .offset(nil)
     end


### PR DESCRIPTION
Speed improvements, this small hack improve performanse for our app by 56%.

Because ORDER BY is expensive the basic idea is to use this function on smaller number of rows, so we pass additional query filter in subquery where we calculate search term ranks.

In our Rails app we use materialized views to display data, collecting data from three big tables ("306694", "750987" and "2896961" rows). For each of these tables we have tsvector_column with data necesarry to search. 

This data are scoped by more parameters and we have to filter data from views, current implementation looks something like this.

` GlobalSearchData.where(account_id: account, department_id: department, status: status).full_text_search(query.downcase).limit(20)` 

This produce to generate search rank for each rows and after that we doing this additional filtering of data.

In the new logic we pass this filter to subquery where ranks are calculated. In this way

` GlobalSearchData.full_text_search([query.downcase,
      subquery_condition: {
        account_id: account,
        department_id: department,
        status: status}
    ]).limit(20)`

The result is performance improvements about 56%.

I know that is not ideal fix, if nothing else I hope it serves as an idea.