### PR TITLE
Add option to ignore white spaces when searching

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -19,7 +19,7 @@ Metrics/BlockLength:
   Exclude:
     - spec/**/*
 
-Layout/AlignParameters:
+Layout/ParameterAlignment:
   EnforcedStyle: with_fixed_indentation
 
 Style/NumericPredicate:
@@ -44,8 +44,8 @@ Bundler/DuplicatedGem:
 
 Style/EmptyMethod:
   EnforcedStyle: expanded
-  
-Layout/IndentFirstArrayElement:
+
+Layout/FirstArrayElementIndentation:
   EnforcedStyle: consistent
 
 Style/Documentation:

--- a/lib/pg_search.rb
+++ b/lib/pg_search.rb
@@ -31,6 +31,9 @@ module PgSearch
   mattr_accessor :unaccent_function
   self.unaccent_function = "unaccent"
 
+  mattr_accessor :replace_function
+  self.replace_function = "replace"
+
   class << self
     def multisearch(*args)
       PgSearch::Document.search(*args)

--- a/lib/pg_search/configuration.rb
+++ b/lib/pg_search/configuration.rb
@@ -88,7 +88,7 @@ module PgSearch
     ].map(&:to_sym)
 
     VALID_VALUES = {
-      ignoring: [:accents]
+      ignoring: %i[accents white_spaces]
     }.freeze
 
     def assert_valid_options(options)

--- a/lib/pg_search/features/feature.rb
+++ b/lib/pg_search/features/feature.rb
@@ -7,7 +7,7 @@ module PgSearch
   module Features
     class Feature
       def self.valid_options
-        %i[only sort_only]
+        %i[only sort_only ignore_white_spaces]
       end
 
       delegate :connection, :quoted_table_name, to: :'@model'

--- a/lib/pg_search/features/tsearch.rb
+++ b/lib/pg_search/features/tsearch.rb
@@ -131,9 +131,16 @@ module PgSearch
       def tsquery
         return "''" if query.blank?
 
-        query_terms = query.split(" ").compact
         tsquery_terms = query_terms.map { |term| tsquery_for_term(term) }
         tsquery_terms.join(options[:any_word] ? ' || ' : ' && ')
+      end
+
+      def query_terms
+        if options[:ignore_white_spaces]
+          [query]
+        else
+          query.split(" ").compact
+        end
       end
 
       def tsdocument

--- a/lib/pg_search/normalizer.rb
+++ b/lib/pg_search/normalizer.rb
@@ -40,7 +40,7 @@ module PgSearch
     def ignore_white_spaces(sql_node)
       Arel::Nodes::NamedFunction.new(
         PgSearch.replace_function,
-        [sql_node, Arel.sql("' ', ''")]
+        [sql_node, Arel.sql("'\s', ''")]
       )
     end
   end

--- a/lib/pg_search/scope_options.rb
+++ b/lib/pg_search/scope_options.rb
@@ -131,11 +131,23 @@ module PgSearch
 
       feature_class.new(
         config.query,
-        feature_options[feature_name],
+        options_for(feature_name),
         config.columns,
         config.model,
         normalizer
       )
+    end
+
+    def options_for(feature_name)
+      if ignore_white_spaces?
+        { ignore_white_spaces: true }.merge(feature_options[feature_name] || {})
+      else
+        feature_options[feature_name]
+      end
+    end
+
+    def ignore_white_spaces?
+      config.ignore.include?(:white_spaces)
     end
 
     def rank

--- a/spec/.rubocop.yml
+++ b/spec/.rubocop.yml
@@ -4,7 +4,7 @@ inherit_from:
 Metrics/LineLength:
   Enabled: false
 
-Lint/HandleExceptions:
+Lint/SuppressedException:
   Enabled: false
 
 Lint/UselessAssignment:

--- a/spec/integration/pg_search_spec.rb
+++ b/spec/integration/pg_search_spec.rb
@@ -928,9 +928,9 @@ describe "an Active Record model which includes PgSearch" do
         expect(ModelWithPgSearch.with_tsearch_and_trigram(trigram_query)).to eq([record])
         expect(ModelWithPgSearch.complex_search(trigram_query)).to include(record)
 
-        # # matches accent
-        # # \303\266 is o with diaeresis
-        # # \303\272 is u with acute accent
+        # matches accent
+        # \303\266 is o with diaeresis
+        # \303\272 is u with acute accent
         accent_query = "gr\303\266\303\272ty"
         expect(ModelWithPgSearch.with_trigram(accent_query)).not_to include(record)
         expect(ModelWithPgSearch.with_trigram_and_ignoring_accents(accent_query)).to include(record)

--- a/spec/lib/pg_search/normalizer_spec.rb
+++ b/spec/lib/pg_search/normalizer_spec.rb
@@ -48,12 +48,74 @@ describe PgSearch::Normalizer do
       end
     end
 
+    context "when config[:ignore] includes :white_spaces" do
+      context "when passed an Arel node" do
+        it "wraps the expression in replace()" do
+          config = double("config", ignore: [:white_spaces])
+          node = Arel::Nodes::NamedFunction.new("foo", [Arel::Nodes.build_quoted("bar")])
+
+          normalizer = PgSearch::Normalizer.new(config)
+          expect(normalizer.add_normalization(node)).to eq("replace(foo('bar'), '\s', '')")
+        end
+
+        context "when a custom replace function is specified" do
+          it "wraps the expression in that function" do
+            allow(PgSearch).to receive(:replace_function).and_return("my_replace")
+            node = Arel::Nodes::NamedFunction.new("foo", [Arel::Nodes.build_quoted("bar")])
+
+            config = double("config", ignore: [:white_spaces])
+
+            normalizer = PgSearch::Normalizer.new(config)
+            expect(normalizer.add_normalization(node)).to eq("my_replace(foo('bar'), '\s', '')")
+          end
+        end
+      end
+
+      context "when passed a String" do
+        it "wraps the expression in replace()" do
+          config = double("config", ignore: [:white_spaces])
+
+          normalizer = PgSearch::Normalizer.new(config)
+          expect(normalizer.add_normalization("foo")).to eq("replace(foo, '\s', '')")
+        end
+
+        context "when a custom replace function is specified" do
+          it "wraps the expression in that function" do
+            allow(PgSearch).to receive(:replace_function).and_return("my_replace")
+
+            config = double("config", ignore: [:white_spaces])
+
+            normalizer = PgSearch::Normalizer.new(config)
+            expect(normalizer.add_normalization("foo")).to eq("my_replace(foo, '\s', '')")
+          end
+        end
+      end
+    end
+
     context "when config[:ignore] does not include :accents" do
+      it "does not wrap the expression with unaccent()" do
+        config = double("config", ignore: [:white_spaces])
+
+        normalizer = PgSearch::Normalizer.new(config)
+        expect(normalizer.add_normalization("foo")).not_to include('unaccent(')
+      end
+    end
+
+    context "when config[:ignore] does not include :white_spaces" do
+      it "does not wrap the expression with replace()" do
+        config = double("config", ignore: [:accents])
+
+        normalizer = PgSearch::Normalizer.new(config)
+        expect(normalizer.add_normalization("foo")).not_to include('replace(')
+      end
+    end
+
+    context "when config[:ignore] is empty" do
       it "passes the expression through" do
         config = double("config", ignore: [])
 
         normalizer = PgSearch::Normalizer.new(config)
-        expect(normalizer.add_normalization("foo")).to eq("foo")
+        expect(normalizer.add_normalization("foo")).to eq('foo')
       end
     end
   end


### PR DESCRIPTION
This PR adds the option to set `ignoring: :white_spaces`, which removes all the white spaces from both the search query and the searched column.

This helps when users can't use spaces on their search (see github `#` for issue reference).

As an example, I can't search for `#add option to...` but I can search for `#addoptionto` which should return a list that includes this PR (as shown in the specs)