### PR TITLE
fix(railtie dependency): check the existence of Railtie in Rails namespace before requiring it

### DIFF
--- a/lib/pg_search.rb
+++ b/lib/pg_search.rb
@@ -71,4 +71,4 @@ ActiveSupport.on_load(:active_record) do
   require "pg_search/document"
 end
 
-require "pg_search/railtie" if defined?(Rails)
+require "pg_search/railtie" if defined?(Rails::Railtie)


### PR DESCRIPTION
If you use pg_search in a non-rails project what uses `actionmailer` the project fails to load because [actionmailer uses actionview](https://github.com/rails/rails/blob/f741f56da3712b943b5584d03df661fc38aa7169/actionmailer/actionmailer.gemspec#L37) what [uses rails-html-sanitizer](https://github.com/rails/rails/blob/f741f56da3712b943b5584d03df661fc38aa7169/actionview/actionview.gemspec#L39) what defines [`Rails` namespace](https://github.com/rails/rails-html-sanitizer/blob/51dc564c6509201070f72456bb2c13f87bb373d6/lib/rails-html-sanitizer.rb#L6) though it doesn't have `Railtie` in it.