### PR TITLE
Take addictional attributes into consideration on rebuild

### DIFF
--- a/lib/pg_search/multisearch/rebuilder.rb
+++ b/lib/pg_search/multisearch/rebuilder.rb
@@ -13,7 +13,7 @@ module PgSearch
       def rebuild
         if model.respond_to?(:rebuild_pg_search_documents)
           model.rebuild_pg_search_documents
-        elsif conditional? || dynamic?
+        elsif conditional? || dynamic? || additional_attributes?
           model.find_each(&:update_pg_search_document)
         else
           model.connection.execute(rebuild_sql)
@@ -31,6 +31,10 @@ module PgSearch
       def dynamic?
         column_names = model.columns.map(&:name)
         columns.any? { |column| !column_names.include?(column.to_s) }
+      end
+
+      def additional_attributes?
+        model.pg_search_multisearchable_options.key?(:additional_attributes)
       end
 
       def connection

--- a/spec/lib/pg_search/multisearch/rebuilder_spec.rb
+++ b/spec/lib/pg_search/multisearch/rebuilder_spec.rb
@@ -223,6 +223,31 @@ describe PgSearch::Multisearch::Rebuilder do
             expect(record.pg_search_document).to be_present
           end
         end
+
+        context "when only addicional_attributes is set" do
+          with_model :Model do
+            table do |t|
+              t.string :name
+            end
+
+            model do
+              include PgSearch::Model
+              multisearchable against: :name,
+                              additional_attributes: ->(obj) { { additional_attribute_column: "#{obj.class}::#{obj.id}" } }
+            end
+          end
+
+          it "calls update_pg_search_document on each record" do
+            record_1 = Model.create!(name: "record_1")
+            record_2 = Model.create!(name: "record_2")
+
+            rebuilder = PgSearch::Multisearch::Rebuilder.new(Model)
+            rebuilder.rebuild
+
+            expect(record_1.reload.pg_search_document.additional_attribute_column).to eq("Model::#{record_1.id}")
+            expect(record_2.reload.pg_search_document.additional_attribute_column).to eq("Model::#{record_2.id}")
+          end
+        end
       end
 
       context "and multisearchable is conditional" do

--- a/spec/lib/pg_search/multisearch/rebuilder_spec.rb
+++ b/spec/lib/pg_search/multisearch/rebuilder_spec.rb
@@ -224,7 +224,7 @@ describe PgSearch::Multisearch::Rebuilder do
           end
         end
 
-        context "when only addicional_attributes is set" do
+        context "when only additional_attributes is set" do
           with_model :Model do
             table do |t|
               t.string :name

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -25,4 +25,7 @@ DOCUMENTS_SCHEMA = lambda do |t|
   t.belongs_to :searchable, polymorphic: true, index: true
   t.text :content
   t.timestamps null: false
+
+  # Used to test additional_attributes setup
+  t.text :additional_attribute_column
 end


### PR DESCRIPTION
Exactly what @zzk  did in https://github.com/Casecommons/pg_search/pull/317/files but with specs.

I tried to only create the new column to `pg_search_documents` on my specific spec but failing to do that I changed the `DOCUMENTS_SCHEMA` . Happy to change that 