### PR TITLE
Fixes #446, enable usage of pg_search with multithreaded servers like puma

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -3,7 +3,6 @@ require:
   - rubocop-rails
   - rubocop-rake
   - rubocop-rspec
-  - rubocop-thread_safety
 
 AllCops:
   TargetRubyVersion: 2.5
@@ -103,7 +102,7 @@ RSpec/ExpectInHook:
   Enabled: false
 
 RSpec/FilePath:
-  CustomTransform:
+  CustomTransform: 
     TSearch: "tsearch"
     DMetaphone: "dmetaphone"
 

--- a/lib/pg_search.rb
+++ b/lib/pg_search.rb
@@ -2,7 +2,7 @@
 
 require "active_record"
 require "active_support/concern"
-require "active_support/core_ext/module/attribute_accessors_per_thread"
+require "active_support/core_ext/module/attribute_accessors"
 require "active_support/core_ext/string/strip"
 
 require "pg_search/configuration"
@@ -27,10 +27,10 @@ module PgSearch
     base.include PgSearch::Model
   end
 
-  thread_mattr_accessor :multisearch_options
+  mattr_accessor :multisearch_options
   self.multisearch_options = {}
 
-  thread_mattr_accessor :unaccent_function
+  mattr_accessor :unaccent_function
   self.unaccent_function = "unaccent"
 
   class << self

--- a/lib/pg_search/model.rb
+++ b/lib/pg_search/model.rb
@@ -21,13 +21,11 @@ module PgSearch
         end
       end
 
-      # rubocop:disable ThreadSafety/ClassAndModuleAttributes
       def multisearchable(options = {})
         include PgSearch::Multisearchable
         class_attribute :pg_search_multisearchable_options
         self.pg_search_multisearchable_options = options
       end
-      # rubocop:enable ThreadSafety/ClassAndModuleAttributes
     end
 
     def method_missing(symbol, *args)

--- a/pg_search.gemspec
+++ b/pg_search.gemspec
@@ -29,7 +29,6 @@ Gem::Specification.new do |s| # rubocop:disable Metrics/BlockLength
   s.add_development_dependency 'rubocop-rails'
   s.add_development_dependency 'rubocop-rake'
   s.add_development_dependency 'rubocop-rspec'
-  s.add_development_dependency 'rubocop-thread_safety', '>= 0.4.1'
   s.add_development_dependency 'simplecov'
   s.add_development_dependency 'warning'
   s.add_development_dependency 'with_model', '>= 1.2'

--- a/spec/lib/pg_search_spec.rb
+++ b/spec/lib/pg_search_spec.rb
@@ -269,8 +269,6 @@ describe PgSearch do
     it "does not disable multisearch on other threads" do
       values = Queue.new
       sync = Queue.new
-
-      # rubocop:disable ThreadSafety/NewThread
       Thread.new do
         values.push described_class.multisearch_enabled?
         sync.pop # wait
@@ -278,7 +276,6 @@ describe PgSearch do
         sync.pop # wait
         values.push described_class.multisearch_enabled?
       end
-      # rubocop:enable ThreadSafety/NewThread
 
       multisearch_enabled_before = values.pop
       multisearch_enabled_inside = nil


### PR DESCRIPTION
This reverts commit 7ff41966026d990db95cda8ad4414f33264e734d.

Fixes #446. Users were reporting problems after this PR using multithreaded servers like puma. I decided to revert the whole commit because except for the trailing whitespace that was removed, all that `rubocop-thread_safety` would achieve is that we'd have to add ignore comments.

Sadly I was unable to write a failing test for this in our own system, even with system tests that use puma as their webserver. I'd have to check if puma settings are somehow different in development and test and in which way. Others have also reported that this was [the case](https://github.com/Casecommons/pg_search/issues/446#issuecomment-696089239)

For reproduction steps to reproduce the error with even simple setups, see https://github.com/Casecommons/pg_search/issues/446#issuecomment-701550610.

All credit goes to the people in #446 however, especially @connorshea who found the commit that needed to be reverted.