### PR TITLE
Change delete_all to delete_by in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -319,7 +319,7 @@ To remove all of the documents for a given class, you can simply delete all of
 the PgSearch::Document records.
 
 ```ruby
-PgSearch::Document.delete_all(searchable_type: "Animal")
+PgSearch::Document.delete_by(searchable_type: "Animal")
 ```
 
 To regenerate the documents for a given class, run:


### PR DESCRIPTION
While setting up multisearch I noticed what I believe to be a little error in the documentation:

```ruby
PgSearch::Document.delete_all(searchable_type: "TheModel")
# ArgumentError: wrong number of arguments (given 1, expected 0)

PgSearch::Document.delete_by(searchable_type: "TheModel")
# PgSearch::Document Destroy (1.1ms)  DELETE FROM "pg_search_documents" WHERE "pg_search_documents"."searchable_type" = $1 ...
```