### PR TITLE
Preserve column selection when chaining ::with_pg_search_highlight

### DIFF
--- a/lib/pg_search/scope_options.rb
+++ b/lib/pg_search/scope_options.rb
@@ -37,11 +37,8 @@ module PgSearch
 
       def with_pg_search_highlight
         scope = self
-        scope.select(pg_search_highlight_field)
-      end
-
-      def pg_search_highlight_field
-        "(#{highlight}) AS pg_search_highlight, #{table_name}.*"
+        scope = scope.select("#{table_name}.*") unless scope.select_values.any?
+        scope.select("(#{highlight}) AS pg_search_highlight")
       end
 
       def highlight

--- a/spec/integration/pg_search_spec.rb
+++ b/spec/integration/pg_search_spec.rb
@@ -407,6 +407,15 @@ describe "an Active Record model which includes PgSearch" do
         expect(results).to eq([winner, loser])
       end
 
+      it 'preserves column selection when with_pg_search_rank is chained after a select()' do
+        loser = ModelWithPgSearch.create!(title: 'foo', content: 'bar')
+
+        results = ModelWithPgSearch.search_content('bar').select(:content).with_pg_search_rank
+
+        expect(results.length).to be 1
+        expect(results.first.as_json.keys).to contain_exactly('id', 'content', 'pg_search_rank')
+      end
+
       it 'allows pg_search_rank along with a join' do
         parent_1 = ParentModel.create!(id: 98)
         parent_2 = ParentModel.create!(id: 99)
@@ -614,7 +623,7 @@ describe "an Active Record model which includes PgSearch" do
       describe "highlighting" do
         before do
           ["Strip Down", "Down", "Down and Out", "Won't Let You Down"].each do |name|
-            ModelWithPgSearch.create! content: name
+            ModelWithPgSearch.create! title: 'Just a title', content: name
           end
         end
 
@@ -634,6 +643,12 @@ describe "an Active Record model which includes PgSearch" do
             result = ModelWithPgSearch.search_content("Let").with_pg_search_highlight.first
 
             expect(result.pg_search_highlight).to eq("Won't <b>Let</b> You Down")
+          end
+
+          it 'preserves column selection when with_pg_search_highlight is chained after a select()' do
+            result = ModelWithPgSearch.search_content("Let").select(:content).with_pg_search_highlight.first
+
+            expect(result.as_json.keys).to contain_exactly('id', 'content', 'pg_search_highlight')
           end
         end
 


### PR DESCRIPTION
Hello,

I have recently started experimenting with postgres' full-text search capabilities. So far, the experience I've had with *pg_seach* has been very pleasant so kudos to the maintainers of this nice library 🙂👏 

I've been doing my experiments on a large set of data that closely mimics what we have in production, which made me realize that it would be best if I could `select()` a limited set of columns for performance reasons, which – if I'm not mistaken – is currently not possible when using the scope `::with_pg_search_highlight`.

This PR is a proposal to implement a similar logic than what is currently performed in `::with_pg_search_rank`'s definition. Apologies in advance if I've missed the reason why it was decided not to implement this behaviour in `::with_pg_search_highlight`.