### PR TITLE
Update multisearch README rebuild example

### DIFF
--- a/README.md
+++ b/README.md
@@ -380,7 +380,7 @@ class Movie < ActiveRecord::Base
      INSERT INTO pg_search_documents (searchable_type, searchable_id, content, created_at, updated_at)
        SELECT 'Movie' AS searchable_type,
               movies.id AS searchable_id,
-              (movies.name || ' ' || directors.name) AS content,
+              CONCAT_WS(' ', movies.name, directors.name) AS content,
               now() AS created_at,
               now() AS updated_at
        FROM movies
@@ -390,6 +390,7 @@ class Movie < ActiveRecord::Base
   end
 end
 ```
+**Note:** If using PostgreSQL before 9.1, replace the `CONCAT_WS()` function call with double-pipe concatenation, eg. `(movies.name || ' ' || directors.name)`. However, now be aware that if *any* of the joined values is NULL then the final `content` value will also be NULL, whereas `CONCAT_WS()` will selectively ignore NULL values.
 
 #### Disabling multi-search indexing temporarily
 


### PR DESCRIPTION
The provided double-pipe concatenation example has a gotcha regarding handling of NULL values, which can result in an "unexpected" empty `content` value. 

I've swapped this for a use of `CONCAT_WS()` which is more forgiving/readable, and has been supported since Postgres 9.1 (released 10 years ago). A note has been added for those unfortunate enough to be working on very old databases. Maybe this isn't even necessary, but some might consider the concatenation more "proper".