### PR TITLE
Optionally disable transaction when rebuilding documents

### DIFF
--- a/README.md
+++ b/README.md
@@ -335,6 +335,13 @@ like so:
 PgSearch::Multisearch.rebuild(Product, clean_up: false)
 ```
 
+```rebuild``` runs inside a single transaction. To run outside of a transaction,
+you can pass ```transactional: false``` like so:
+
+```ruby
+PgSearch::Multisearch.rebuild(Product, transactional: false)
+```
+
 Rebuild is also available as a Rake task, for convenience.
 
     $ rake pg_search:multisearch:rebuild[BlogPost]

--- a/lib/pg_search/multisearch.rb
+++ b/lib/pg_search/multisearch.rb
@@ -5,7 +5,7 @@ require "pg_search/multisearch/rebuilder"
 module PgSearch
   module Multisearch
     class << self
-      def rebuild(model, deprecated_clean_up = nil, clean_up: true)
+      def rebuild(model, deprecated_clean_up = nil, clean_up: true, transactional: true)
         unless deprecated_clean_up.nil?
           ActiveSupport::Deprecation.warn(
             "pg_search 3.0 will no longer accept a boolean second argument to PgSearchMultisearch.rebuild, " \
@@ -14,10 +14,18 @@ module PgSearch
           clean_up = deprecated_clean_up
         end
 
-        model.transaction do
-          PgSearch::Document.where(searchable_type: model.base_class.name).delete_all if clean_up
-          Rebuilder.new(model).rebuild
+        if transactional
+          model.transaction { execute(model, clean_up) }
+        else
+          execute(model, clean_up)
         end
+      end
+
+      private
+
+      def execute(model, clean_up)
+        PgSearch::Document.where(searchable_type: model.base_class.name).delete_all if clean_up
+        Rebuilder.new(model).rebuild
       end
     end
 

--- a/spec/lib/pg_search/multisearch_spec.rb
+++ b/spec/lib/pg_search/multisearch_spec.rb
@@ -33,6 +33,15 @@ describe PgSearch::Multisearch do
       expect(model).to have_received(:transaction).once
     end
 
+    context "when transactional is false" do
+      it "does not operate inside a transaction" do
+        allow(model).to receive(:transaction)
+
+        described_class.rebuild(model, transactional: false)
+        expect(model).not_to have_received(:transaction)
+      end
+    end
+
     describe "cleaning up search documents for this model" do
       before do
         connection.execute <<~SQL.squish


### PR DESCRIPTION
The rebuild process can be pretty time-consuming with a large number of rows, or even if you use dynamic attributes. For that reason, clients should have the option of running the process outside of a transaction.