### PR TITLE
Don't require against if tsvector_column is specified

### DIFF
--- a/lib/pg_search/configuration.rb
+++ b/lib/pg_search/configuration.rb
@@ -92,8 +92,8 @@ module PgSearch
     }.freeze
 
     def assert_valid_options(options)
-      unless options[:against] || options[:associated_against]
-        raise ArgumentError, "the search scope #{@name} must have :against or :associated_against in its options"
+      unless options[:against] || options[:associated_against] || using_tsvector_column?(options[:using])
+        raise ArgumentError, "the search scope #{@name} must have :against or :associated_against in its options or specify a tsvector_column"
       end
 
       options.assert_valid_keys(VALID_KEYS)
@@ -103,6 +103,13 @@ module PgSearch
           raise ArgumentError, ":#{key} cannot accept #{value}" unless values_for_key.include?(value)
         end
       end
+    end
+
+    def using_tsvector_column?(options)
+      return unless options.is_a?(Hash)
+
+      options.dig(:dmetaphone, :tsvector_column).present? ||
+        options.dig(:tsearch, :tsvector_column).present?
     end
   end
 end

--- a/spec/integration/pg_search_spec.rb
+++ b/spec/integration/pg_search_spec.rb
@@ -140,6 +140,22 @@ describe "an Active Record model which includes PgSearch" do
             }.to raise_error(ArgumentError, /against/)
           end
         end
+
+        context "when a tsvector column is specified" do
+          it "does not raise an exception when invoked" do
+            ModelWithPgSearch.pg_search_scope :with_unknown_ignoring, {
+              using: {
+                tsearch: {
+                  tsvector_column: "tsv"
+                }
+              }
+            }
+
+            expect {
+              ModelWithPgSearch.with_unknown_ignoring("foo")
+            }.not_to raise_error
+          end
+        end
       end
     end
   end


### PR DESCRIPTION
I've only been using the gem a short time, so I could be missing a use case where this change doesn't make sense.

It seems to me like if you're using a tsvector column, you don't need to specify `against`. Keeping the `against` option specified isn't a big deal, but it does mean that you need to keep it up-to-date with whatever populates the tsv column, which is a little strange.