### PR TITLE
tsearch: add configuration to customize columns separator

### DIFF
--- a/lib/pg_search/features/feature.rb
+++ b/lib/pg_search/features/feature.rb
@@ -24,8 +24,8 @@ module PgSearch
 
       attr_reader :query, :options, :all_columns, :model, :normalizer
 
-      def document
-        columns.map(&:to_sql).join(" || ' ' || ")
+      def document(separator = " ")
+        columns.map(&:to_sql).join(" || '#{separator}' || ")
       end
 
       def columns

--- a/lib/pg_search/features/tsearch.rb
+++ b/lib/pg_search/features/tsearch.rb
@@ -29,7 +29,7 @@ module PgSearch
       def ts_headline
         Arel::Nodes::NamedFunction.new("ts_headline", [
           dictionary,
-          arel_wrap(document),
+          arel_wrap(document((options[:highlight] || {})[:separator])),
           arel_wrap(tsquery),
           Arel::Nodes.build_quoted(ts_headline_options)
         ]).to_sql


### PR DESCRIPTION
When performing tsearch with Highlighting, the resulting query result
concatenates the searched columns with a space.

It can be hard to extract the different column data result if both
data are text (containing spaces).

In order to avoid this issue, we can allow users to customize the
columns separator (which needs to be one of the word boundaries used
by the query dictionnary).

Partial solution for #336.