### PR TITLE
Add U+02BB/U+02BC to disallow tsquery characters

### DIFF
--- a/lib/pg_search/features/tsearch.rb
+++ b/lib/pg_search/features/tsearch.rb
@@ -94,7 +94,7 @@ module PgSearch
         end
       end
 
-      DISALLOWED_TSQUERY_CHARACTERS = /['?\\:‘’]/.freeze
+      DISALLOWED_TSQUERY_CHARACTERS = /['?\\:‘’ʻʼ]/.freeze
 
       def tsquery_for_term(unsanitized_term)
         if options[:negation] && unsanitized_term.start_with?("!")

--- a/spec/integration/pg_search_spec.rb
+++ b/spec/integration/pg_search_spec.rb
@@ -1174,11 +1174,16 @@ describe "an Active Record model which includes PgSearch" do
       end
 
       context "when the query includes accents" do
-        it "does not create an erroneous tsquery expression" do
-          included = ModelWithPgSearch.create!(title: "Weird L‘Content")
+        let(:term) { "L#{%w[‘ ’ ʻ ʼ].sample}Content" }
+        let(:included) { ModelWithPgSearch.create!(title: "Weird #{term}") }
+        let(:results) { ModelWithPgSearch.search_title_without_accents(term) }
 
-          results = ModelWithPgSearch.search_title_without_accents("L‘Content")
-          expect(results).to eq([included])
+        before do
+          ModelWithPgSearch.create!(title: 'FooBar')
+        end
+
+        it "does not create an erroneous tsquery expression" do
+          expect(results).to contain_exactly(included)
         end
       end
     end


### PR DESCRIPTION
Added U+02BB/U+02BC quotes to `DISALLOWED_TSQUERY_CHARACTERS` otherwise get an error
`PG::SyntaxError: ERROR: syntax error in tsquery:`

p.s. Does it make sense to add PgSearch configurator to provide an ability to set this characters outside the gem?