### PR TITLE
Readme updates for delete_by and update_if option

### DIFF
--- a/README.md
+++ b/README.md
@@ -359,15 +359,11 @@ pg_search_documents tables. The following will set the schema search path to
 
     $ rake pg_search:multisearch:rebuild[BlogPost,my_schema]
 
-For models that are multisearchable :against methods that directly map to
+For models that are multisearchable `:against` methods that directly map to
 Active Record attributes, an efficient single SQL statement is run to update
-the pg_search_documents table all at once. However, if you call any dynamic
-methods in :against, the following strategy will be used:
-
-```ruby
-PgSearch::Document.delete_by(searchable_type: "Ingredient")
-Ingredient.find_each { |record| record.update_pg_search_document }
-```
+the `pg_search_documents` table all at once. However, if you call any dynamic
+methods in `:against` then `update_pg_search_document` will be called on the
+individual records being indexed in batches.
 
 You can also provide a custom implementation for rebuilding the documents by
 adding a class method called `rebuild_pg_search_documents` to your model.


### PR DESCRIPTION
#454 made some changes to the readme to replace `delete_all` with `delete_by`, but one instance remains and this PR updates that

The current readme has an example for multisearch's `update_if` using the ActiveRecord `*_changed?` method to determine if the pg search document should be updated. However, because `update_if` is evaluated in an `after_save` callback the dirty flags have already been cleared which may result in pg search documents not being updated as expected. Instead, I'd suggest people use `*_previously_changed?` as it returns whether the attribute was changed before the model was saved is more useful for more cases.

There are some whitespace changes included in this PR which I can remove if you'd prefer.