### PR TITLE
spec/support/database: support running postgres in docker

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,11 @@
+version: '3.2'
+
+services:
+  postgres:
+    image: postgres:12
+    ports:
+      - 5432:5432
+    restart: on-failure
+    environment:
+      POSTGRES_PASSWORD: postgres
+      POSTGRES_DB: pg_search_test

--- a/spec/support/database.rb
+++ b/spec/support/database.rb
@@ -11,10 +11,11 @@ end
 
 begin
   connection_options = { adapter: 'postgresql', database: 'pg_search_test', min_messages: 'warning' }
-  if ENV["CI"]
+  if ENV["CI"] || ENV["DOCKER"]
     connection_options[:username] = 'postgres'
     connection_options[:password] = 'postgres'
   end
+  connection_options[:host] = 'localhost' if ENV["DOCKER"]
   ActiveRecord::Base.establish_connection(connection_options)
   connection = ActiveRecord::Base.connection
   connection.execute("SELECT 1")


### PR DESCRIPTION
I'd rather not install postgres, its extensions, or configure test databases (and setup access to them) on my development machine. I'd much rather use a Docker container dedicated to that task that I can destroy as I see fit, which keeps my development environment clean. This trivial PR adds support for that workflow by adding a `docker-compose.yml` file that sets up a PostgreSQL image configured to run pg_search's test suite. It also adds support to `spec/support/database` for using that container's PostgreSQL instance to run the test suite by simply checking if the `DOCKER` environment variable is set.