### PR TITLE
column: add support for Arel::Nodes::SqlLiteral

### DIFF
--- a/lib/pg_search/configuration/column.rb
+++ b/lib/pg_search/configuration/column.rb
@@ -9,18 +9,20 @@ module PgSearch
 
       def initialize(column_name, weight, model)
         @name = column_name.to_s
-        @column_name = column_name.to_s
+        @column_name = column_name
         @weight = weight
         @model = model
         @connection = model.connection
       end
 
       def full_name
+        return @column_name if @column_name.is_a?(Arel::Nodes::SqlLiteral)
+
         "#{table_name}.#{column_name}"
       end
 
       def to_sql
-        "coalesce(#{expression}::text, '')"
+        "coalesce((#{expression})::text, '')"
       end
 
       private
@@ -30,7 +32,7 @@ module PgSearch
       end
 
       def column_name
-        @connection.quote_column_name(@column_name)
+        @connection.quote_column_name(@name)
       end
 
       def expression

--- a/spec/lib/pg_search/configuration/column_spec.rb
+++ b/spec/lib/pg_search/configuration/column_spec.rb
@@ -7,6 +7,7 @@ describe PgSearch::Configuration::Column do
     with_model :Model do
       table do |t|
         t.string :name
+        t.json :object
       end
     end
 
@@ -14,18 +15,29 @@ describe PgSearch::Configuration::Column do
       column = described_class.new("name", nil, Model)
       expect(column.full_name).to eq(%(#{Model.quoted_table_name}."name"))
     end
+
+    it "returns nested json attributes" do
+      column = described_class.new(Arel.sql("object->>'name'"), nil, Model)
+      expect(column.full_name).to eq(%(object->>'name'))
+    end
   end
 
   describe "#to_sql" do
     with_model :Model do
       table do |t|
         t.string :name
+        t.json :object
       end
     end
 
     it "returns an expression that casts the column to text and coalesces it with an empty string" do
       column = described_class.new("name", nil, Model)
-      expect(column.to_sql).to eq(%{coalesce(#{Model.quoted_table_name}."name"::text, '')})
+      expect(column.to_sql).to eq(%{coalesce((#{Model.quoted_table_name}."name")::text, '')})
+    end
+
+    it "returns an expression that casts the nested json attribute to text and coalesces it with an empty string" do
+      column = described_class.new(Arel.sql("object->>'name'"), nil, Model)
+      expect(column.to_sql).to eq(%{coalesce((object->>'name')::text, '')})
     end
   end
 end

--- a/spec/lib/pg_search/features/dmetaphone_spec.rb
+++ b/spec/lib/pg_search/features/dmetaphone_spec.rb
@@ -23,7 +23,7 @@ describe PgSearch::Features::DMetaphone do
 
       feature = described_class.new(query, options, columns, Model, normalizer)
       expect(feature.rank.to_sql).to eq(
-        %{(ts_rank((to_tsvector('simple', pg_search_dmetaphone(coalesce(#{Model.quoted_table_name}."name"::text, ''))) || to_tsvector('simple', pg_search_dmetaphone(coalesce(#{Model.quoted_table_name}."content"::text, '')))), (to_tsquery('simple', ''' ' || pg_search_dmetaphone('query') || ' ''')), 0))}
+        %{(ts_rank((to_tsvector('simple', pg_search_dmetaphone(coalesce((#{Model.quoted_table_name}."name")::text, ''))) || to_tsvector('simple', pg_search_dmetaphone(coalesce((#{Model.quoted_table_name}."content")::text, '')))), (to_tsquery('simple', ''' ' || pg_search_dmetaphone('query') || ' ''')), 0))}
       )
     end
   end
@@ -48,7 +48,7 @@ describe PgSearch::Features::DMetaphone do
 
       feature = described_class.new(query, options, columns, Model, normalizer)
       expect(feature.conditions.to_sql).to eq(
-        %{((to_tsvector('simple', pg_search_dmetaphone(coalesce(#{Model.quoted_table_name}."name"::text, ''))) || to_tsvector('simple', pg_search_dmetaphone(coalesce(#{Model.quoted_table_name}."content"::text, '')))) @@ (to_tsquery('simple', ''' ' || pg_search_dmetaphone('query') || ' ''')))}
+        %{((to_tsvector('simple', pg_search_dmetaphone(coalesce((#{Model.quoted_table_name}."name")::text, ''))) || to_tsvector('simple', pg_search_dmetaphone(coalesce((#{Model.quoted_table_name}."content")::text, '')))) @@ (to_tsquery('simple', ''' ' || pg_search_dmetaphone('query') || ' ''')))}
       )
     end
   end

--- a/spec/lib/pg_search/features/trigram_spec.rb
+++ b/spec/lib/pg_search/features/trigram_spec.rb
@@ -20,9 +20,9 @@ describe PgSearch::Features::Trigram do
 
   let(:coalesced_columns) do
     <<~SQL.squish
-      coalesce(#{Model.quoted_table_name}."name"::text, '')
+      coalesce((#{Model.quoted_table_name}."name")::text, '')
         || ' '
-        || coalesce(#{Model.quoted_table_name}."content"::text, '')
+        || coalesce((#{Model.quoted_table_name}."content")::text, '')
     SQL
   end
 
@@ -88,7 +88,7 @@ describe PgSearch::Features::Trigram do
         let(:options) { { only: :name } }
 
         it 'only searches against the select column' do
-          coalesced_column = "coalesce(#{Model.quoted_table_name}.\"name\"::text, '')"
+          coalesced_column = "coalesce((#{Model.quoted_table_name}.\"name\")::text, '')"
           expect(feature.conditions.to_sql).to eq("('#{query}' % (#{coalesced_column}))")
         end
       end

--- a/spec/lib/pg_search/features/tsearch_spec.rb
+++ b/spec/lib/pg_search/features/tsearch_spec.rb
@@ -24,7 +24,7 @@ describe PgSearch::Features::TSearch do
 
       feature = described_class.new(query, options, columns, Model, normalizer)
       expect(feature.rank.to_sql).to eq(
-        %{(ts_rank((to_tsvector('simple', coalesce(#{Model.quoted_table_name}."name"::text, '')) || to_tsvector('simple', coalesce(#{Model.quoted_table_name}."content"::text, ''))), (to_tsquery('simple', ''' ' || 'query' || ' ''')), 0))}
+        %{(ts_rank((to_tsvector('simple', coalesce((#{Model.quoted_table_name}."name")::text, '')) || to_tsvector('simple', coalesce((#{Model.quoted_table_name}."content")::text, ''))), (to_tsquery('simple', ''' ' || 'query' || ' ''')), 0))}
       )
     end
 
@@ -67,7 +67,7 @@ describe PgSearch::Features::TSearch do
 
       feature = described_class.new(query, options, columns, Model, normalizer)
       expect(feature.conditions.to_sql).to eq(
-        %{((to_tsvector('simple', coalesce(#{Model.quoted_table_name}."name"::text, '')) || to_tsvector('simple', coalesce(#{Model.quoted_table_name}."content"::text, ''))) @@ (to_tsquery('simple', ''' ' || 'query' || ' ''')))}
+        %{((to_tsvector('simple', coalesce((#{Model.quoted_table_name}."name")::text, '')) || to_tsvector('simple', coalesce((#{Model.quoted_table_name}."content")::text, ''))) @@ (to_tsquery('simple', ''' ' || 'query' || ' ''')))}
       )
     end
 
@@ -84,7 +84,7 @@ describe PgSearch::Features::TSearch do
 
         feature = described_class.new(query, options, columns, Model, normalizer)
         expect(feature.conditions.to_sql).to eq(
-          %{((to_tsvector('simple', coalesce(#{Model.quoted_table_name}."name"::text, '')) || to_tsvector('simple', coalesce(#{Model.quoted_table_name}."content"::text, ''))) @@ (to_tsquery('simple', '!' || ''' ' || 'query' || ' ''')))}
+          %{((to_tsvector('simple', coalesce((#{Model.quoted_table_name}."name")::text, '')) || to_tsvector('simple', coalesce((#{Model.quoted_table_name}."content")::text, ''))) @@ (to_tsquery('simple', '!' || ''' ' || 'query' || ' ''')))}
         )
       end
     end
@@ -102,7 +102,7 @@ describe PgSearch::Features::TSearch do
 
         feature = described_class.new(query, options, columns, Model, normalizer)
         expect(feature.conditions.to_sql).to eq(
-          %{((to_tsvector('simple', coalesce(#{Model.quoted_table_name}."name"::text, '')) || to_tsvector('simple', coalesce(#{Model.quoted_table_name}."content"::text, ''))) @@ (to_tsquery('simple', ''' ' || '!query' || ' ''')))}
+          %{((to_tsvector('simple', coalesce((#{Model.quoted_table_name}."name")::text, '')) || to_tsvector('simple', coalesce((#{Model.quoted_table_name}."content")::text, ''))) @@ (to_tsquery('simple', ''' ' || '!query' || ' ''')))}
         )
       end
     end
@@ -164,7 +164,7 @@ describe PgSearch::Features::TSearch do
 
       feature = described_class.new(query, options, columns, Model, normalizer)
       expect(feature.highlight.to_sql).to eq(
-        "(ts_headline('simple', (coalesce(#{Model.quoted_table_name}.\"name\"::text, '')), (to_tsquery('simple', ''' ' || 'query' || ' ''')), ''))"
+        "(ts_headline('simple', (coalesce((#{Model.quoted_table_name}.\"name\")::text, '')), (to_tsquery('simple', ''' ' || 'query' || ' ''')), ''))"
       )
     end
 
@@ -189,7 +189,7 @@ describe PgSearch::Features::TSearch do
 
         feature = described_class.new(query, options, columns, Model, normalizer)
 
-        expected_sql = %{(ts_headline('spanish', (coalesce(#{Model.quoted_table_name}."name"::text, '') || ' ' || coalesce(#{Model.quoted_table_name}."content"::text, '')), (to_tsquery('spanish', ''' ' || 'query' || ' ''')), 'StartSel = "<b>", StopSel = "</b>"'))}
+        expected_sql = %{(ts_headline('spanish', (coalesce((#{Model.quoted_table_name}."name")::text, '') || ' ' || coalesce((#{Model.quoted_table_name}."content")::text, '')), (to_tsquery('spanish', ''' ' || 'query' || ' ''')), 'StartSel = "<b>", StopSel = "</b>"'))}
 
         expect(feature.highlight.to_sql).to eq(expected_sql)
       end
@@ -221,7 +221,7 @@ describe PgSearch::Features::TSearch do
 
         feature = described_class.new(query, options, columns, Model, normalizer)
 
-        expected_sql = %{(ts_headline('simple', (coalesce(#{Model.quoted_table_name}."name"::text, '')), (to_tsquery('simple', ''' ' || 'query' || ' ''')), 'StartSel = "<start class=""search"">", StopSel = "<stop>", MaxFragments = 3, MaxWords = 123, MinWords = 456, ShortWord = 4, FragmentDelimiter = "&hellip;", HighlightAll = TRUE'))}
+        expected_sql = %{(ts_headline('simple', (coalesce((#{Model.quoted_table_name}."name")::text, '')), (to_tsquery('simple', ''' ' || 'query' || ' ''')), 'StartSel = "<start class=""search"">", StopSel = "<stop>", MaxFragments = 3, MaxWords = 123, MinWords = 456, ShortWord = 4, FragmentDelimiter = "&hellip;", HighlightAll = TRUE'))}
 
         expect(feature.highlight.to_sql).to eq(expected_sql)
       end
@@ -252,7 +252,7 @@ describe PgSearch::Features::TSearch do
         feature = described_class.new(query, options, columns, Model, normalizer)
 
         highlight_sql = ActiveSupport::Deprecation.silence { feature.highlight.to_sql }
-        expected_sql = %{(ts_headline('simple', (coalesce(#{Model.quoted_table_name}."name"::text, '')), (to_tsquery('simple', ''' ' || 'query' || ' ''')), 'StartSel = "<start class=""search"">", StopSel = "<stop>", MaxFragments = 3, MaxWords = 123, MinWords = 456, ShortWord = 4, FragmentDelimiter = "&hellip;", HighlightAll = FALSE'))}
+        expected_sql = %{(ts_headline('simple', (coalesce((#{Model.quoted_table_name}."name")::text, '')), (to_tsquery('simple', ''' ' || 'query' || ' ''')), 'StartSel = "<start class=""search"">", StopSel = "<stop>", MaxFragments = 3, MaxWords = 123, MinWords = 456, ShortWord = 4, FragmentDelimiter = "&hellip;", HighlightAll = FALSE'))}
 
         expect(highlight_sql).to eq(expected_sql)
       end


### PR DESCRIPTION
This PR resolves #252, allowing for more more advanced columns, such as extracting elements out of json arrays, or fields out of json objects. This is intended to be entirely backward compatible.