### PR TITLE
add support for ILIKE search feature

### DIFF
--- a/lib/pg_search/features.rb
+++ b/lib/pg_search/features.rb
@@ -3,6 +3,7 @@
 require "pg_search/features/feature"
 
 require "pg_search/features/dmetaphone"
+require "pg_search/features/ilike"
 require "pg_search/features/trigram"
 require "pg_search/features/tsearch"
 

--- a/lib/pg_search/features/ilike.rb
+++ b/lib/pg_search/features/ilike.rb
@@ -1,0 +1,29 @@
+module PgSearch
+  module Features
+    class ILike < Feature
+      def conditions
+        Arel::Nodes::Grouping.new(
+          Arel::Nodes::InfixOperation.new(
+            'ILIKE',
+            normalized_document,
+            normalized_query
+          )
+        )
+      end
+
+      def rank
+        Arel::Nodes::Grouping.new(Arel.sql('0')) # no ranking or delegate to tsearch like DMetaphone?
+      end
+
+      private
+
+      def normalized_query
+        Arel.sql(connection.quote("%#{query}%"))
+      end
+
+      def normalized_document
+        Arel::Nodes::Grouping.new(Arel.sql(document))
+      end
+    end
+  end
+end

--- a/lib/pg_search/scope_options.rb
+++ b/lib/pg_search/scope_options.rb
@@ -114,6 +114,7 @@ module PgSearch
 
     FEATURE_CLASSES = {
       dmetaphone: Features::DMetaphone,
+      ilike: Features::ILike,
       tsearch: Features::TSearch,
       trigram: Features::Trigram
     }.freeze

--- a/spec/lib/pg_search/features/ilike_spec.rb
+++ b/spec/lib/pg_search/features/ilike_spec.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "ostruct"
+
+# rubocop:disable RSpec/MultipleMemoizedHelpers, RSpec/NestedGroups
+describe PgSearch::Features::ILike do
+  subject(:feature) { described_class.new(query, options, columns, Model, normalizer) }
+
+  let(:query) { "lolwut" }
+  let(:options) { {} }
+  let(:columns) {
+    [
+      PgSearch::Configuration::Column.new(:name, nil, Model),
+      PgSearch::Configuration::Column.new(:content, nil, Model)
+    ]
+  }
+  let(:normalizer) { PgSearch::Normalizer.new(config) }
+  let(:config) { OpenStruct.new(ignore: []) }
+
+  let(:coalesced_columns) do
+    <<~SQL.squish
+      coalesce(#{Model.quoted_table_name}."name"::text, '')
+        || ' '
+        || coalesce(#{Model.quoted_table_name}."content"::text, '')
+    SQL
+  end
+
+  with_model :Model do
+    table do |t|
+      t.string :name
+      t.string :content
+    end
+  end
+
+  describe "conditions" do
+    it "escapes the search document and query" do
+      expect(feature.conditions.to_sql).to eq("((#{coalesced_columns}) ILIKE '%#{query}%')")
+    end
+  end
+end


### PR DESCRIPTION
This adds an additional feature to support doing an ILIKE search to find substrings in within the document. I see a bunch of open issues this would help resolve (#3, #356, #324 etc).

If this strategy looks sane to you I can finish it off (update README) but wanted to do a sanity check first.