### PR TITLE
Add ranking order to set higher priorities over rank

### DIFF
--- a/lib/pg_search/configuration.rb
+++ b/lib/pg_search/configuration.rb
@@ -75,6 +75,10 @@ module PgSearch
       options[:order_within_rank]
     end
 
+    def ranking_order
+      options[:ranking_order]
+    end
+
     private
 
     attr_reader :options
@@ -84,7 +88,7 @@ module PgSearch
     end
 
     VALID_KEYS = %w[
-      against ranked_by ignoring using query associated_against order_within_rank
+      against ranked_by ignoring using query associated_against order_within_rank ranking_order
     ].map(&:to_sym)
 
     VALID_VALUES = {


### PR DESCRIPTION
This PR changes how the gem is ranked by default `pg_search.rank DESC`, followed up by `order_within_rank` as the tiebreaker. Now, it supports ordering by other fields BEFORE `pg_search.rank`

In my case, ranking is not the most important to be considered first. For instance, we have options to sort by relevance order (1) AND posted date order (2). The requirement for (2) will respect the posted date order before another matching, similar to partitioning by date and apply ranking inside the partitions.

This option `ranking_order` somehow is opposite to `order_within_rank`, please suggest me a proper name.