### PR TITLE
Enhance Highlight Customization using the columns Option

### DIFF
--- a/README.md
+++ b/README.md
@@ -840,6 +840,37 @@ See the
 [documentation](https://www.postgresql.org/docs/current/static/textsearch-controls.html)
 for details on the meaning of each option.
 
+Use the `columns` option to create `pg_search_<custom_name>_highlight` with the necessary columns.
+
+
+```ruby
+class Person < ActiveRecord::Base
+  include PgSearch::Model
+  pg_search_scope :search,
+                  against: [:portrait, :bio],
+                  using: {
+                    tsearch: {
+                      highlight: {
+                        columns: {
+                          first: :portrait,
+                          second: [:portrait, :bio]
+                        }
+                      }
+                    }
+                  }
+end
+
+Person.create!(
+  :portrait => "He's driven by an innate curiosity to discover every corner of Alberta.",
+  :bio => "Born in rural Alberta, where the buffalo roam."
+)
+
+first_match = Person.search("Alberta").with_pg_search_highlight.first
+first_match.pg_search_first_highlight => "He's driven by an innate curiosity to discover every corner of <b>Alberta</b>."
+first_match.pg_search_second_highlight => "He's driven by an innate curiosity to discover every corner of <b>Alberta</b>. Born in rural <b>Alberta</b>, where the buffalo roam."
+```
+
+
 #### :dmetaphone (Double Metaphone soundalike search)
 
 [Double Metaphone](http://en.wikipedia.org/wiki/Double_Metaphone) is an

--- a/lib/pg_search.rb
+++ b/lib/pg_search.rb
@@ -67,6 +67,20 @@ module PgSearch
         "to access the pg_search_highlight attribute on returned records"
     end
   end
+
+  class PgSearchHighlightCustomColumnsNotSelected < StandardError
+    attr_reader :attribute
+
+    def initialize(attribute)
+      @attribute = attribute
+    end
+
+    def message
+      "You must chain .with_pg_search_highlight after the pg_search_scope " \
+        "and define highlight: { columns: } option in pg_search_scope " \
+        "to access the #{attribute} attribute on returned records"
+    end
+  end
 end
 
 require "pg_search/railtie" if defined?(Rails::Railtie)

--- a/lib/pg_search/features/feature.rb
+++ b/lib/pg_search/features/feature.rb
@@ -10,6 +10,8 @@ module PgSearch
         %i[only sort_only]
       end
 
+      attr_reader :options
+
       delegate :connection, :quoted_table_name, to: :@model
 
       def initialize(query, options, all_columns, model, normalizer)
@@ -22,7 +24,7 @@ module PgSearch
 
       private
 
-      attr_reader :query, :options, :all_columns, :model, :normalizer
+      attr_reader :query, :all_columns, :model, :normalizer
 
       def document
         columns.map(&:to_sql).join(" || ' ' || ")

--- a/lib/pg_search/model.rb
+++ b/lib/pg_search/model.rb
@@ -38,6 +38,10 @@ module PgSearch
         raise PgSearchHighlightNotSelected unless respond_to?(:pg_search_highlight)
 
         read_attribute(:pg_search_highlight)
+      when /^pg_search_(.+)_highlight$/
+        raise PgSearchHighlightCustomColumnsNotSelected.new(symbol) unless respond_to?(symbol)
+
+        read_attribute(symbol)
       else
         super
       end

--- a/lib/pg_search/scope_options.rb
+++ b/lib/pg_search/scope_options.rb
@@ -38,11 +38,27 @@ module PgSearch
       def with_pg_search_highlight
         scope = self
         scope = scope.select("#{table_name}.*") unless scope.select_values.any?
-        scope.select("(#{highlight}) AS pg_search_highlight")
+        add_highlight_columns(scope)
       end
 
-      def highlight
-        tsearch.highlight.to_sql
+      def add_highlight_columns(scope)
+        if highlight_columns.present?
+          highlight_columns.each do |name, cols|
+            scope = scope.select("(#{highlight(cols)}) AS pg_search_#{name}_highlight")
+          end
+
+          scope
+        else
+          scope.select("(#{highlight}) AS pg_search_highlight")
+        end
+      end
+
+      def highlight(columns = [])
+        tsearch.highlight(columns).to_sql
+      end
+
+      def highlight_columns
+        tsearch.options.dig(:highlight, :columns)
       end
     end
 


### PR DESCRIPTION
Enhance Highlight Customization using the columns Option


This pull request introduces the utilization of the columns option to create customized highlighting for search results in the PgSearch module. The enhancement offers a more flexible and tailored way to generate `pg_search_<custom_name>_highlight` columns based on specified columns within the model.

Example:
```

pg_search_scope :search_by_keyword, against: {
    title: 'A',
    body: 'B',
    summary: 'C'
  }, using: {
    tsearch: {
      prefix: true,
      highlight: {
        fields: {
          title: :title,
          content: %i[body summary]
        }
        StartSel: '<mark>',
        StopSel: '</mark>'
      }
    }
  }

Article.by_keyword('account').first.pg_search_title_highlight
=> "How to create <mark>account</mark>?"

Article.by_keyword('account').first.pg_search_content_highligh
 => Select New Agency <mark>Account</mark> and after you create your agency, the <mark>Account</mark> is here."
```