### PR TITLE
Drop support for Ruby 2.7

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby-version: ['2.7', '3.0', '3.1', '3.2', '3.3']
+        ruby-version: ['3.0', '3.1', '3.2', '3.3']
         active-record-version-env:
           - ACTIVE_RECORD_VERSION="~> 6.0.0"
           - ACTIVE_RECORD_VERSION="~> 6.1.0"

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -9,7 +9,7 @@ inherit_gem:
   standard: config/base.yml
 
 AllCops:
-  TargetRubyVersion: 2.7
+  TargetRubyVersion: 3.0
   NewCops: disable
   Exclude:
     - bin/**/*

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Read the blog post introducing PgSearch at https://tanzu.vmware.com/content/blog
 
 ## REQUIREMENTS
 
-*   Ruby 2.7+
+*   Ruby 3.0+
 *   Active Record 6.0+
 *   PostgreSQL 9.2+
 *   [PostgreSQL extensions](https://github.com/Casecommons/pg_search/wiki/Installing-PostgreSQL-Extensions) for certain features

--- a/pg_search.gemspec
+++ b/pg_search.gemspec
@@ -21,5 +21,5 @@ Gem::Specification.new do |s|
   s.add_dependency "activerecord", ">= 6.0"
   s.add_dependency "activesupport", ">= 6.0"
 
-  s.required_ruby_version = ">= 2.7"
+  s.required_ruby_version = ">= 3.0"
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 require "warning"
-# Ignore Ruby 2.7 warnings from Active Record
-Warning.ignore :keyword_separation
 
 # https://github.com/grodowski/undercover#setting-up-required-lcov-reporting
 require "simplecov"


### PR DESCRIPTION
Ruby 2.7 has been EOL since 2023-03-31
