### PR TITLE
Drop support for Active Record 6.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,6 @@ jobs:
       matrix:
         ruby-version: ['3.0', '3.1', '3.2', '3.3']
         active-record-version-env:
-          - ACTIVE_RECORD_VERSION="~> 6.0.0"
           - ACTIVE_RECORD_VERSION="~> 6.1.0"
           - ACTIVE_RECORD_VERSION="~> 7.0.0"
           - ACTIVE_RECORD_VERSION="~> 7.1.0"

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Read the blog post introducing PgSearch at https://tanzu.vmware.com/content/blog
 ## REQUIREMENTS
 
 *   Ruby 3.0+
-*   Active Record 6.0+
+*   Active Record 6.1+
 *   PostgreSQL 9.2+
 *   [PostgreSQL extensions](https://github.com/Casecommons/pg_search/wiki/Installing-PostgreSQL-Extensions) for certain features
 

--- a/pg_search.gemspec
+++ b/pg_search.gemspec
@@ -18,8 +18,8 @@ Gem::Specification.new do |s|
   s.files = `git ls-files -z`.split("\x0")
   s.require_paths = ["lib"]
 
-  s.add_dependency "activerecord", ">= 6.0"
-  s.add_dependency "activesupport", ">= 6.0"
+  s.add_dependency "activerecord", ">= 6.1"
+  s.add_dependency "activesupport", ">= 6.1"
 
   s.required_ruby_version = ">= 3.0"
 end


### PR DESCRIPTION
Active Record 6.0 has been EOL since 2023-06-01
