### PR TITLE
Update trigram word_similarity code example

### DIFF
--- a/README.md
+++ b/README.md
@@ -959,15 +959,16 @@ class Sentence < ActiveRecord::Base
 
   pg_search_scope :similarity_like,
                   against: :name,
+                  using: [:trigram]
+
+
+  pg_search_scope :word_similarity_like,
+                  against: :name,
                   using: {
                     trigram: {
                       word_similarity: true
                     }
                   }
-
-  pg_search_scope :word_similarity_like,
-                  against: :name,
-                  using: [:trigram]
 end
 
 sentence = Sentence.create! name: "Those are two words."


### PR DESCRIPTION
I think the code example for `:word_similarity` setting for trigram is flipped, such that `word_similarity` is enabled on `:similarity_like` and not on `:word_similarity_like`. This makes the return not work as expected, seeing as how `word_similarity` function in pg gives `0.8` similarity score vs `0.18` for `similarity`. 