### PR TITLE
Fix compatibility with ActiveRecord 7.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,10 +41,14 @@ jobs:
           - ACTIVE_RECORD_VERSION="~> 6.1.0"
           - ACTIVE_RECORD_VERSION="~> 7.0.0"
           - ACTIVE_RECORD_VERSION="~> 7.1.0"
+          - ACTIVE_RECORD_VERSION="~> 7.2.0.beta2"
         allow-failure: [false]
         include:
           - ruby-version: '3.3'
             active-record-version-env: ACTIVE_RECORD_BRANCH="main"
+            allow-failure: true
+          - ruby-version: '3.3'
+            active-record-version-env: ACTIVE_RECORD_BRANCH="7-2-stable"
             allow-failure: true
           - ruby-version: '3.3'
             active-record-version-env: ACTIVE_RECORD_BRANCH="7-1-stable"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,8 +41,11 @@ jobs:
           - ACTIVE_RECORD_VERSION="~> 6.1.0"
           - ACTIVE_RECORD_VERSION="~> 7.0.0"
           - ACTIVE_RECORD_VERSION="~> 7.1.0"
-          - ACTIVE_RECORD_VERSION="~> 7.2.0.beta2"
+          - ACTIVE_RECORD_VERSION="~> 7.2.0"
         allow-failure: [false]
+        exclude:
+          - ruby-version: '3.0'
+            active-record-version-env: ACTIVE_RECORD_VERSION="~> 7.2.0"
         include:
           - ruby-version: '3.3'
             active-record-version-env: ACTIVE_RECORD_BRANCH="main"

--- a/lib/pg_search/scope_options.rb
+++ b/lib/pg_search/scope_options.rb
@@ -95,13 +95,27 @@ module PgSearch
           .reject { |_feature_name, feature_options| feature_options && feature_options[:sort_only] }
           .map { |feature_name, _feature_options| feature_for(feature_name).conditions }
 
-      # https://github.com/rails/rails/pull/51492
-      if ActiveRecord.version >= Gem::Version.new("7.2.0.beta1")
+      or_node(expressions)
+    end
+
+    # https://github.com/rails/rails/pull/51492
+    # :nocov:
+    # standard:disable Lint/DuplicateMethods
+    or_arity = Arel::Nodes::Or.instance_method(:initialize).arity
+    case or_arity
+    when 1
+      def or_node(expressions)
         Arel::Nodes::Or.new(expressions)
-      else
+      end
+    when 2
+      def or_node(expressions)
         expressions.inject { |accumulator, expression| Arel::Nodes::Or.new(accumulator, expression) }
       end
+    else
+      raise "Unsupported arity #{or_arity} for Arel::Nodes::Or#initialize"
     end
+    # :nocov:
+    # standard:enable Lint/DuplicateMethods
 
     def order_within_rank
       config.order_within_rank || "#{primary_key} ASC"


### PR DESCRIPTION
The interface for `Or` arel node was changed in https://github.com/rails/rails/pull/51492.
This currently prevents our upgrade to rails 7.2.

Fixes #536.