### PR TITLE
Add support for trigram strict_word_similarity function

### DIFF
--- a/lib/pg_search/features/trigram.rb
+++ b/lib/pg_search/features/trigram.rb
@@ -4,7 +4,7 @@ module PgSearch
   module Features
     class Trigram < Feature
       def self.valid_options
-        super + %i[threshold word_similarity]
+        super + %i[threshold word_similarity strict_word_similarity]
       end
 
       def conditions
@@ -29,23 +29,31 @@ module PgSearch
 
       private
 
+      def strict_word_similarity?
+        options[:strict_word_similarity]
+      end
+
       def word_similarity?
         options[:word_similarity]
       end
 
       def similarity_function
-        if word_similarity?
-          "word_similarity"
+        if strict_word_similarity?
+          'strict_word_similarity'
+        elsif word_similarity?
+          'word_similarity'
         else
-          "similarity"
+          'similarity'
         end
       end
 
       def infix_operator
-        if word_similarity?
-          "<%"
+        if strict_word_similarity?
+          '<<%'
+        elsif word_similarity?
+          '<%'
         else
-          "%"
+          '%'
         end
       end
 

--- a/spec/lib/pg_search/features/trigram_spec.rb
+++ b/spec/lib/pg_search/features/trigram_spec.rb
@@ -50,6 +50,17 @@ describe PgSearch::Features::Trigram do
       end
     end
 
+    context "when searching by strict_word_similarity" do
+      let(:options) do
+        {strict_word_similarity: true}
+      end
+
+      it 'uses the "<<%" operator when searching by word_similarity' do
+        config.ignore = []
+        expect(feature.conditions.to_sql).to eq("('#{query}' <<% (#{coalesced_columns}))")
+      end
+    end
+
     context "when ignoring accents" do
       it "escapes the search document and query, but not the accent function" do
         config.ignore = [:accents]
@@ -78,6 +89,18 @@ describe PgSearch::Features::Trigram do
         it 'uses a minimum similarity expression instead of the "<%" operator' do
           expect(feature.conditions.to_sql).to eq(
             "(word_similarity('#{query}', (#{coalesced_columns})) >= 0.5)"
+          )
+        end
+      end
+
+      context "when searching by strict_word_similarity" do
+        let(:options) do
+          {threshold: 0.5, strict_word_similarity: true}
+        end
+
+        it 'uses a minimum similarity expression instead of the "<<%" operator' do
+          expect(feature.conditions.to_sql).to eq(
+            "(strict_word_similarity('#{query}', (#{coalesced_columns})) >= 0.5)"
           )
         end
       end


### PR DESCRIPTION
Allows using the postgres function `strict_word_similarity` for trigram matching, that, [according to postgres](https://www.postgresql.org/docs/current/pgtrgm.html#:~:text=Thus%2C%20the%20strict_word_similarity%20function%20is,similarity%20for%20parts%20of%20words.&text=Returns%20true%20if%20its%20arguments,similarity%20threshold%20set%20by%20pg_trgm.), is 

> useful for finding the similarity to whole words, while word_similarity is more suitable for finding the similarity for parts of words


It's my first contribution, so I'm sorry if I miss something.

If this is something you would like to add to the project, I wonder if we should validate that `word_similarity` and `strict_word_similarity` options cannot both be given, as only one will be applied. Or even if it's worth it to make a breaking change and replace the `word_similarity` option by a `similarity_function` option, or something like that.