### PR TITLE
Remove `activesupport` from explicit dependencies

### DIFF
--- a/pg_search.gemspec
+++ b/pg_search.gemspec
@@ -19,7 +19,6 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
 
   s.add_dependency "activerecord", ">= 6.1"
-  s.add_dependency "activesupport", ">= 6.1"
 
   s.required_ruby_version = ">= 3.0"
 end


### PR DESCRIPTION
`activerecord` already depends on `activesupport`. 
Moreover, when trying to upgrade the gem without `--conservative` option, it tries to also upgrade `activesupport` dependencies, which is not needed.