### PR TITLE
use primary key type

### DIFF
--- a/lib/pg_search/migration/templates/create_pg_search_documents.rb.erb
+++ b/lib/pg_search/migration/templates/create_pg_search_documents.rb.erb
@@ -1,9 +1,9 @@
 class CreatePgSearchDocuments < ActiveRecord::Migration<%= migration_version %>
   def up
     say_with_time("Creating table for pg_search multisearch") do
-      create_table :pg_search_documents do |t|
+      create_table :pg_search_documents, id: primary_key_type do |t|
         t.text :content
-        t.belongs_to :searchable, polymorphic: true, index: true
+        t.belongs_to :searchable, polymorphic: true, index: true, type: primary_key_type
         t.timestamps null: false
       end
     end
@@ -13,5 +13,12 @@ class CreatePgSearchDocuments < ActiveRecord::Migration<%= migration_version %>
     say_with_time("Dropping table for pg_search multisearch") do
       drop_table :pg_search_documents
     end
+  end
+
+  private
+
+  def primary_key_type
+    config = Rails.configuration.generators
+    config.options[config.orm][:primary_key_type] || :primary_key
   end
 end


### PR DESCRIPTION
I encountered an issue because I use UUIDs by default, which caused conflicts with polymorphic associations. This change resolves the inconsistency and ensures compatibility.