### PR TITLE
Add more characters that map to single quote via unaccent

### DIFF
--- a/lib/pg_search/features/tsearch.rb
+++ b/lib/pg_search/features/tsearch.rb
@@ -96,8 +96,7 @@ module PgSearch
         end
       end
 
-      DISALLOWED_TSQUERY_CHARACTERS = /['?\\:‘’ʻʼ]/ # standard:disable Lint/UselessConstantScoping
-
+      DISALLOWED_TSQUERY_CHARACTERS = /['?\\:‘’ʻʼʹʽˈ＇ŉ]/ # standard:disable Lint/UselessConstantScoping
       def tsquery_for_term(unsanitized_term)
         if options[:negation] && unsanitized_term.start_with?("!")
           unsanitized_term[0] = ""

--- a/spec/integration/pg_search_spec.rb
+++ b/spec/integration/pg_search_spec.rb
@@ -1185,7 +1185,7 @@ describe "an Active Record model which includes PgSearch" do
       end
 
       context "when the query includes accents" do
-        let(:term) { "L#{%w[‘ ’ ʻ ʼ].sample}Content" }
+        let(:term) { "L#{%w[‘ ’ ʻ ʼ ʹ ʽ ˈ ＇ ŉ].sample}Content" }
         let(:included) { ModelWithPgSearch.create!(title: "Weird #{term}") }
         let(:results) { ModelWithPgSearch.search_title_without_accents(term) }
 


### PR DESCRIPTION
The full list can be seen in `/usr/share/postgresql/tsearch_data/unaccent.rules` from Postgres

Related to #487 