### PR TITLE
Ensure the `unaccent` normalizer sanitizes the query term post normalization

### DIFF
--- a/lib/pg_search/features/tsearch.rb
+++ b/lib/pg_search/features/tsearch.rb
@@ -96,7 +96,7 @@ module PgSearch
         end
       end
 
-      DISALLOWED_TSQUERY_CHARACTERS = /['?\\:‘’ʻʼʹʽˈ＇ŉ]/ # standard:disable Lint/UselessConstantScoping
+      DISALLOWED_TSQUERY_CHARACTERS = /['?\\:]/ # standard:disable Lint/UselessConstantScoping
       def tsquery_for_term(unsanitized_term)
         if options[:negation] && unsanitized_term.start_with?("!")
           unsanitized_term[0] = ""

--- a/lib/pg_search/features/tsearch.rb
+++ b/lib/pg_search/features/tsearch.rb
@@ -96,8 +96,7 @@ module PgSearch
         end
       end
 
-      DISALLOWED_TSQUERY_CHARACTERS = /['?\\:‘’ʻʼ]/ # standard:disable Lint/UselessConstantScoping
-
+      DISALLOWED_TSQUERY_CHARACTERS = /['?\\:‘’ʻʼʹʽˈ＇ŉ]/ # standard:disable Lint/UselessConstantScoping
       def tsquery_for_term(unsanitized_term)
         if options[:negation] && unsanitized_term.start_with?("!")
           unsanitized_term[0] = ""

--- a/lib/pg_search/normalizer.rb
+++ b/lib/pg_search/normalizer.rb
@@ -6,6 +6,8 @@ module PgSearch
       @config = config
     end
 
+    DISALLOWED_CHARACTERS = "'[''?\\:]'"
+
     def add_normalization(sql_expression)
       return sql_expression unless config.ignore.include?(:accents)
 
@@ -17,8 +19,16 @@ module PgSearch
       end
 
       Arel::Nodes::NamedFunction.new(
-        PgSearch.unaccent_function,
-        [sql_node]
+        "regexp_replace",
+        [
+          Arel::Nodes::NamedFunction.new(
+            PgSearch.unaccent_function,
+            [sql_node]
+          ),
+          Arel.sql(DISALLOWED_CHARACTERS),
+          Arel.sql("''"),
+          Arel.sql("'g'")
+        ]
       ).to_sql
     end
 

--- a/spec/integration/pg_search_spec.rb
+++ b/spec/integration/pg_search_spec.rb
@@ -1185,7 +1185,7 @@ describe "an Active Record model which includes PgSearch" do
       end
 
       context "when the query includes accents" do
-        let(:term) { "L#{%w[‘ ’ ʻ ʼ].sample}Content" }
+        let(:term) { "L#{%w[‘ ’ ʻ ʼ ʹ ʽ ˈ ＇ ŉ].sample}Content" }
         let(:included) { ModelWithPgSearch.create!(title: "Weird #{term}") }
         let(:results) { ModelWithPgSearch.search_title_without_accents(term) }
 

--- a/spec/lib/pg_search/features/trigram_spec.rb
+++ b/spec/lib/pg_search/features/trigram_spec.rb
@@ -52,7 +52,7 @@ describe PgSearch::Features::Trigram do
       let(:ignore) { [:accents] }
 
       it "escapes the search document and query, but not the accent function" do
-        expect(feature.conditions.to_sql).to eq("(unaccent('#{query}') % (unaccent(#{coalesced_columns})))")
+        expect(feature.conditions.to_sql).to eq("(regexp_replace(unaccent('#{query}'), '[''?\\:]', '', 'g') % (regexp_replace(unaccent(#{coalesced_columns}), '[''?\\:]', '', 'g')))")
       end
     end
 

--- a/spec/lib/pg_search/normalizer_spec.rb
+++ b/spec/lib/pg_search/normalizer_spec.rb
@@ -12,7 +12,7 @@ describe PgSearch::Normalizer do
           node = Arel::Nodes::NamedFunction.new("foo", [Arel::Nodes.build_quoted("bar")])
 
           normalizer = described_class.new(config)
-          expect(normalizer.add_normalization(node)).to eq("unaccent(foo('bar'))")
+          expect(normalizer.add_normalization(node)).to eq("regexp_replace(unaccent(foo('bar')), '[''?\\:]', '', 'g')")
         end
 
         context "when a custom unaccent function is specified" do
@@ -23,7 +23,7 @@ describe PgSearch::Normalizer do
             config = instance_double(PgSearch::Configuration, "config", ignore: [:accents])
 
             normalizer = described_class.new(config)
-            expect(normalizer.add_normalization(node)).to eq("my_unaccent(foo('bar'))")
+            expect(normalizer.add_normalization(node)).to eq("regexp_replace(my_unaccent(foo('bar')), '[''?\\:]', '', 'g')")
           end
         end
       end
@@ -33,7 +33,7 @@ describe PgSearch::Normalizer do
           config = instance_double(PgSearch::Configuration, "config", ignore: [:accents])
 
           normalizer = described_class.new(config)
-          expect(normalizer.add_normalization("foo")).to eq("unaccent(foo)")
+          expect(normalizer.add_normalization("foo")).to eq("regexp_replace(unaccent(foo), '[''?\\:]', '', 'g')")
         end
 
         context "when a custom unaccent function is specified" do
@@ -43,7 +43,7 @@ describe PgSearch::Normalizer do
             config = instance_double(PgSearch::Configuration, "config", ignore: [:accents])
 
             normalizer = described_class.new(config)
-            expect(normalizer.add_normalization("foo")).to eq("my_unaccent(foo)")
+            expect(normalizer.add_normalization("foo")).to eq("regexp_replace(my_unaccent(foo), '[''?\\:]', '', 'g')")
           end
         end
       end


### PR DESCRIPTION
When an sql string is fed to `to_tsquery`, postgres functions get executed prior to string conversion to tsquery.

`unaccent` function may create unexpected single quote symbols, that will lead to "invalid tsquery" error from Postgres.

Wrap the `unaccent` output in `regexp_replace`, to make sure the query term is properly sanitized post normalization.

Related to #487 #558 