### PR TITLE
Update actions/checkout to v6

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,7 +60,7 @@ jobs:
             allow-failure: true
     continue-on-error: ${{ matrix.allow-failure }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:


### PR DESCRIPTION
## Summary

- Bump `actions/checkout` from v4 to v6 in `.github/workflows/ci.yml`

GitHub deprecated Node.js 20 in Actions runners. The previous v4 release runs on Node.js 20 and will be forced to Node.js 24 in June 2026, then removed in September 2026. v6.0.2 (released 2026-01-09) runs on Node.js 24 natively.

## Test plan

- [ ] CI workflow runs green on this PR