### PR TITLE
Clean up CI matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,40 +37,43 @@ jobs:
       fail-fast: false
       matrix:
         ruby-version: ["3.3", "3.4", "4.0"]
-        active-record-version-env:
-          - ACTIVE_RECORD_VERSION="~> 7.2.0"
-          - ACTIVE_RECORD_VERSION="~> 8.0.0"
-          - ACTIVE_RECORD_VERSION="~> 8.1.0"
+        active-record-env:
+          - "ACTIVE_RECORD_VERSION=~> 7.2.0"
+          - "ACTIVE_RECORD_VERSION=~> 8.0.0"
+          - "ACTIVE_RECORD_VERSION=~> 8.1.0"
         allow-failure: [false]
         include:
           - ruby-version: "ruby-head"
-            active-record-version-env: ACTIVE_RECORD_VERSION="~> 8.1.0"
+            active-record-env: "ACTIVE_RECORD_VERSION=~> 8.1.0"
             allow-failure: true
           - ruby-version: "4.0"
-            active-record-version-env: ACTIVE_RECORD_BRANCH="main"
+            active-record-env: "ACTIVE_RECORD_BRANCH=main"
             allow-failure: true
           - ruby-version: "4.0"
-            active-record-version-env: ACTIVE_RECORD_BRANCH="8-1-stable"
+            active-record-env: "ACTIVE_RECORD_BRANCH=8-1-stable"
             allow-failure: true
           - ruby-version: "4.0"
-            active-record-version-env: ACTIVE_RECORD_BRANCH="8-0-stable"
+            active-record-env: "ACTIVE_RECORD_BRANCH=8-0-stable"
             allow-failure: true
           - ruby-version: "4.0"
-            active-record-version-env: ACTIVE_RECORD_BRANCH="7-2-stable"
+            active-record-env: "ACTIVE_RECORD_BRANCH=7-2-stable"
             allow-failure: true
     continue-on-error: ${{ matrix.allow-failure }}
     steps:
       - uses: actions/checkout@v6
+      - name: Select ActiveRecord version
+        env:
+          ACTIVE_RECORD_ENV: ${{ matrix.active-record-env }}
+        run: echo "$ACTIVE_RECORD_ENV" >> "$GITHUB_ENV"
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby-version }}
           bundler-cache: true
+          cache-version: ${{ matrix.active-record-env }}
       - name: Set up test database
         env:
           PGPASSWORD: postgres
         run: createdb pg_search_test
-      - name: Update bundle
-        run: ${{ matrix.active-record-version-env }} bundle update
       - name: Run tests
-        run: ${{ matrix.active-record-version-env }} bundle exec rake
+        run: bundle exec rake

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,6 @@ jobs:
       CI: true
       PGHOST: 127.0.0.1
       PGUSER: postgres
-      PGPASS: postgres
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,10 +12,18 @@ on:
     - cron: "0 18 * * 6" # Saturdays at 12pm CST
   workflow_dispatch:
 
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   test:
     name: Ruby ${{ matrix.ruby-version }} / Active Record ${{ matrix.active-record.label }}
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     services:
       postgres:
         image: postgres:latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,7 @@ on:
 
 jobs:
   test:
+    name: Ruby ${{ matrix.ruby-version }} / Active Record ${{ matrix.active-record.label }}
     runs-on: ubuntu-latest
     services:
       postgres:
@@ -37,40 +38,40 @@ jobs:
       fail-fast: false
       matrix:
         ruby-version: ["3.3", "3.4", "4.0"]
-        active-record-env:
-          - "ACTIVE_RECORD_VERSION=~> 7.2.0"
-          - "ACTIVE_RECORD_VERSION=~> 8.0.0"
-          - "ACTIVE_RECORD_VERSION=~> 8.1.0"
+        active-record:
+          - { label: "7.2", env: "ACTIVE_RECORD_VERSION=~> 7.2.0" }
+          - { label: "8.0", env: "ACTIVE_RECORD_VERSION=~> 8.0.0" }
+          - { label: "8.1", env: "ACTIVE_RECORD_VERSION=~> 8.1.0" }
         allow-failure: [false]
         include:
+          - ruby-version: "4.0"
+            active-record: { label: "main", env: "ACTIVE_RECORD_BRANCH=main" }
+            allow-failure: true
+          - ruby-version: "4.0"
+            active-record: { label: "8-1-stable", env: "ACTIVE_RECORD_BRANCH=8-1-stable" }
+            allow-failure: true
+          - ruby-version: "4.0"
+            active-record: { label: "8-0-stable", env: "ACTIVE_RECORD_BRANCH=8-0-stable" }
+            allow-failure: true
+          - ruby-version: "4.0"
+            active-record: { label: "7-2-stable", env: "ACTIVE_RECORD_BRANCH=7-2-stable" }
+            allow-failure: true
           - ruby-version: "ruby-head"
-            active-record-env: "ACTIVE_RECORD_VERSION=~> 8.1.0"
-            allow-failure: true
-          - ruby-version: "4.0"
-            active-record-env: "ACTIVE_RECORD_BRANCH=main"
-            allow-failure: true
-          - ruby-version: "4.0"
-            active-record-env: "ACTIVE_RECORD_BRANCH=8-1-stable"
-            allow-failure: true
-          - ruby-version: "4.0"
-            active-record-env: "ACTIVE_RECORD_BRANCH=8-0-stable"
-            allow-failure: true
-          - ruby-version: "4.0"
-            active-record-env: "ACTIVE_RECORD_BRANCH=7-2-stable"
+            active-record: { label: "8.1", env: "ACTIVE_RECORD_VERSION=~> 8.1.0" }
             allow-failure: true
     continue-on-error: ${{ matrix.allow-failure }}
     steps:
       - uses: actions/checkout@v6
       - name: Select ActiveRecord version
         env:
-          ACTIVE_RECORD_ENV: ${{ matrix.active-record-env }}
+          ACTIVE_RECORD_ENV: ${{ matrix.active-record.env }}
         run: echo "$ACTIVE_RECORD_ENV" >> "$GITHUB_ENV"
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby-version }}
           bundler-cache: true
-          cache-version: ${{ matrix.active-record-env }}
+          cache-version: ${{ matrix.active-record.env }}
       - name: Set up test database
         env:
           PGPASSWORD: postgres


### PR DESCRIPTION
## Summary

Tidies up `.github/workflows/ci.yml` across four small commits.

- **Drop the separate `bundle update` step from the matrix.** Previously the matrix prepended `ACTIVE_RECORD_VERSION=...` (or `ACTIVE_RECORD_BRANCH=...`) onto a follow-up `bundle update` step because `setup-ruby`'s bundler-cache install ran before those env vars were in scope — the cached install resolved the gemspec's default Active Record, so a second resolution was needed to swap in the matrix's chosen version. The matrix value is now written to `$GITHUB_ENV` in a step that runs *before* `setup-ruby`, the cached install picks up the right gems on the first try, and the extra step disappears. The new `cache-version` input on `setup-ruby` partitions the bundler cache per matrix entry so different Active Record versions don't collide on the same cache key.
- **Give matrix jobs readable names.** The Active Record matrix axis is now an object with a short `label` and the `env` payload, and the job name template renders as `Ruby <ruby-version> / Active Record <label>` — e.g. `Ruby 3.3 / Active Record 7.2` or `Ruby 4.0 / Active Record main` — instead of the default `test (3.3, ACTIVE_RECORD_VERSION="~> 7.2.0", false)`. The `ruby-head` row is also sorted to the bottom of the include block so the unstable entries are visually grouped.
- **Drop the dead `PGPASS` env.** `PGPASS` is not a libpq variable (the right name is `PGPASSWORD`) and nothing in the repo reads it. The actual password comes from `PGPASSWORD` on the `createdb` step and from a hardcoded `"postgres"` in `spec/support/database.rb` when `CI=true`.
- **Tighten workflow defaults.** Three defensive additions: `permissions: contents: read` at the workflow level so the default `GITHUB_TOKEN` is least-privilege; a `concurrency` group keyed on workflow + ref that cancels superseded PR runs (master pushes and the Saturday cron run to completion); and `timeout-minutes: 20` on the test job to guard against a hung runner — most likely on the `ruby-head` row — eating six hours of the GH Actions budget.

## Test plan

- [ ] CI runs green across the matrix
- [ ] Job names in the Actions UI read as `Ruby <version> / Active Record <label>`
- [ ] A second push to this PR cancels the first run

Generated with [Claude Code](https://claude.com/claude-code)
