### PR TITLE
Use arel for joining with rank table

### DIFF
--- a/lib/pg_search/scope_options.rb
+++ b/lib/pg_search/scope_options.rb
@@ -164,7 +164,13 @@ module PgSearch
     end
 
     def rank_join(rank_table_alias)
-      "INNER JOIN (#{subquery.to_sql}) AS #{rank_table_alias} ON #{primary_key} = #{rank_table_alias}.pg_search_id"
+      arel_table = model.arel_table
+      subquery_arel = subquery.arel.as(rank_table_alias)
+
+      arel_table
+        .join(subquery_arel)
+        .on(arel_table[model.primary_key].eq(subquery_arel[:pg_search_id]))
+        .join_sources
     end
 
     def include_table_aliasing_for_rank(scope)

--- a/spec/integration/pg_search_spec.rb
+++ b/spec/integration/pg_search_spec.rb
@@ -1088,6 +1088,10 @@ describe "an Active Record model which includes PgSearch" do
       it "finds by a combination of the two" do
         expect(Post.search_by_content_with_tsvector("phooey commentone").map(&:id)).to eq([expected.id])
       end
+
+      it "finds by the tsvector column when using order" do
+        expect(Post.search_by_content_with_tsvector("phooey").order("#{Post.table_name}.id").map(&:id)).to eq([expected.id])
+      end
     end
 
     context "when using multiple tsvector columns" do

--- a/spec/integration/pg_search_spec.rb
+++ b/spec/integration/pg_search_spec.rb
@@ -1088,6 +1088,28 @@ describe "an Active Record model which includes PgSearch" do
       it "finds by a combination of the two" do
         expect(Post.search_by_content_with_tsvector("phooey commentone").map(&:id)).to eq([expected.id])
       end
+
+      it "finds by the tsvector column when ordering by an associated table" do
+        # Reference the physical table name that Active Record would normally
+        # leave unaliased. The old string rank join made AliasTracker think the
+        # name was already used and alias this outer join, breaking the order.
+        # https://github.com/Casecommons/pg_search/issues/206
+        results = Post
+          .joins(:comments)
+          .search_by_content_with_tsvector("phooey")
+          .order(Comment.table_name => {id: :asc})
+
+        expect(results).to eq([expected])
+      end
+
+      it "finds by the tsvector column when ordering by an association alias" do
+        results = Post
+          .joins(:comments)
+          .search_by_content_with_tsvector("phooey")
+          .order(comments: {id: :asc})
+
+        expect(results).to eq([expected])
+      end
     end
 
     context "when using multiple tsvector columns" do


### PR DESCRIPTION
Fixes #206.

We faced the same problem as described in the linked issue - when active record creates an alias for one of the tables (the table for the top model or one of the joined tables) and the SQL query become invalid when trying to order or group etc.

The problem is here https://github.com/rails/rails/blob/d5afe4f6811c60dc1400c90624a1bbf77c572da6/activerecord/lib/active_record/associations/alias_tracker.rb#L33-L44

When passing a string JOIN, active record simply grep matches it to decide if aliases are needed, for safety. But when passing arel, it can make smarter decisions.
