### PR TITLE
Declare with_model tables explicitly

### DIFF
--- a/spec/integration/associations_spec.rb
+++ b/spec/integration/associations_spec.rb
@@ -404,6 +404,8 @@ describe "a pg_search_scope" do
 
   context "when merging a pg_search_scope into another model's scope" do
     with_model :ModelWithAssociation do
+      table
+
       model do
         has_many :associated_models
       end
@@ -451,6 +453,8 @@ describe "a pg_search_scope" do
 
   context "when chained onto a has_many association" do
     with_model :Company do
+      table
+
       model do
         has_many :positions
       end

--- a/spec/integration/deprecation_spec.rb
+++ b/spec/integration/deprecation_spec.rb
@@ -5,6 +5,8 @@ require "active_support/core_ext/kernel/reporting"
 
 describe "Including the deprecated PgSearch module" do
   with_model :SomeModel do
+    table
+
     model do
       silence_warnings do
         include PgSearch
@@ -12,7 +14,9 @@ describe "Including the deprecated PgSearch module" do
     end
   end
 
-  with_model :AnotherModel
+  with_model :AnotherModel do
+    table
+  end
 
   it "includes PgSearch::Model" do
     expect(SomeModel.ancestors).to include PgSearch::Model

--- a/spec/integration/pg_search_spec.rb
+++ b/spec/integration/pg_search_spec.rb
@@ -1092,6 +1092,8 @@ describe "an Active Record model which includes PgSearch" do
 
     context "when using multiple tsvector columns" do
       with_model :ModelWithTsvector do
+        table
+
         model do
           include PgSearch::Model
 

--- a/spec/lib/pg_search/multisearch/rebuilder_spec.rb
+++ b/spec/lib/pg_search/multisearch/rebuilder_spec.rb
@@ -7,7 +7,9 @@ describe PgSearch::Multisearch::Rebuilder do
   with_table "pg_search_documents", &DOCUMENTS_SCHEMA
 
   describe "when initialized with a model that is not multisearchable" do
-    with_model :not_multisearchable
+    with_model :not_multisearchable do
+      table
+    end
 
     it "raises an exception" do
       expect {
@@ -23,6 +25,8 @@ describe PgSearch::Multisearch::Rebuilder do
     context "when the model defines .rebuild_pg_search_documents" do
       context "when multisearchable is not conditional" do
         with_model :Model do
+          table
+
           model do
             include PgSearch::Model
 
@@ -210,6 +214,8 @@ describe PgSearch::Multisearch::Rebuilder do
 
         context "when :against includes non-column dynamic methods" do
           with_model :Model do
+            table
+
             model do
               include PgSearch::Model
 

--- a/spec/lib/pg_search/multisearchable_spec.rb
+++ b/spec/lib/pg_search/multisearchable_spec.rb
@@ -8,6 +8,8 @@ describe PgSearch::Multisearchable do
 
   describe "a model that is multisearchable" do
     with_model :ModelThatIsMultisearchable do
+      table
+
       model do
         include PgSearch::Model
 


### PR DESCRIPTION
## Summary

- Make each affected `with_model` test model explicitly declare that it owns an id-only table
- Preserve current test behavior while eliminating warnings about `with_model` 3.0 changing omitted-table semantics

## Test plan

- [x] Affected specs create their standalone models without omitted-table deprecation warnings
- [x] Search and multisearch behavior remains green across all 256 examples
- [x] GitHub Actions passes all 17 checks across Ruby 3.3, 3.4, 4.0, and ruby-head

🤖 Generated with Zed Agent