### PR TITLE
Drop support for Active Record 7.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,7 +46,6 @@ jobs:
       matrix:
         ruby-version: ["3.3", "3.4", "4.0"]
         active-record:
-          - { label: "7.2", env: "ACTIVE_RECORD_VERSION=~> 7.2.0" }
           - { label: "8.0", env: "ACTIVE_RECORD_VERSION=~> 8.0.0" }
           - { label: "8.1", env: "ACTIVE_RECORD_VERSION=~> 8.1.0" }
         allow-failure: [false]
@@ -59,9 +58,6 @@ jobs:
             allow-failure: true
           - ruby-version: "4.0"
             active-record: { label: "8-0-stable", env: "ACTIVE_RECORD_BRANCH=8-0-stable" }
-            allow-failure: true
-          - ruby-version: "4.0"
-            active-record: { label: "7-2-stable", env: "ACTIVE_RECORD_BRANCH=7-2-stable" }
             allow-failure: true
           - ruby-version: "ruby-head"
             active-record: { label: "8.1", env: "ACTIVE_RECORD_VERSION=~> 8.1.0" }

--- a/.standard.yml
+++ b/.standard.yml
@@ -3,4 +3,4 @@ ruby_version: 3.3
 plugins:
   - standard-performance
   - standard-rails:
-      target_rails_version: 7.2
+      target_rails_version: 8.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # pg_search changelog
 
+## Unreleased
+
+* Drop support for Active Record 7.2
+
 ## 2.3.8
 
 * Drop support for Ruby 3.0, 3.1, and 3.2

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,7 +12,7 @@ Don't be discouraged if the maintainers ask you to change your code. We are alwa
 
 Our automated tests start by updating all gems to their latest version. This is by design, because we want to be proactive about compatibility with other libraries. You can do the same by running `bundle update` at any time. To test against a specific version of Active Record, you can set the `ACTIVE_RECORD_VERSION` environment variable.
 
-    $ ACTIVE_RECORD_VERSION=5.0 bundle update
+    $ ACTIVE_RECORD_VERSION="~> 8.0.0" bundle update
 
 Run the tests by running `bundle exec rake`, or `bin/rake` if you use Bundler binstubs. 
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Read the blog post introducing PgSearch at https://tanzu.vmware.com/content/blog
 ## REQUIREMENTS
 
 - Ruby 3.3+
-- Active Record 7.2+
+- Active Record 8.0+
 - PostgreSQL 9.2+
 - [PostgreSQL extensions](https://github.com/Casecommons/pg_search/wiki/Installing-PostgreSQL-Extensions) for certain features
 

--- a/lib/pg_search/migration/generator.rb
+++ b/lib/pg_search/migration/generator.rb
@@ -28,11 +28,7 @@ module PgSearch
       end
 
       def migration_version
-        if ActiveRecord::VERSION::MAJOR >= 5
-          "[#{ActiveRecord::VERSION::MAJOR}.#{ActiveRecord::VERSION::MINOR}]"
-        else
-          ""
-        end
+        "[#{ActiveRecord::VERSION::MAJOR}.#{ActiveRecord::VERSION::MINOR}]"
       end
     end
   end

--- a/lib/pg_search/scope_options.rb
+++ b/lib/pg_search/scope_options.rb
@@ -96,27 +96,8 @@ module PgSearch
           .reject { |_feature_name, feature_options| feature_options && feature_options[:sort_only] }
           .map { |feature_name, _feature_options| feature_for(feature_name).conditions }
 
-      or_node(expressions)
+      Arel::Nodes::Or.new(expressions)
     end
-
-    # https://github.com/rails/rails/pull/51492
-    # :nocov:
-    # standard:disable Lint/DuplicateMethods
-    or_arity = Arel::Nodes::Or.instance_method(:initialize).arity
-    case or_arity
-    when 1
-      def or_node(expressions)
-        Arel::Nodes::Or.new(expressions)
-      end
-    when 2
-      def or_node(expressions)
-        expressions.inject { |accumulator, expression| Arel::Nodes::Or.new(accumulator, expression) }
-      end
-    else
-      raise "Unsupported arity #{or_arity} for Arel::Nodes::Or#initialize"
-    end
-    # :nocov:
-    # standard:enable Lint/DuplicateMethods
 
     def order_within_rank
       config.order_within_rank || "#{primary_key} ASC"

--- a/pg_search.gemspec
+++ b/pg_search.gemspec
@@ -18,8 +18,8 @@ Gem::Specification.new do |s|
   s.files = `git ls-files -z`.split("\x0")
   s.require_paths = ["lib"]
 
-  s.add_dependency "activerecord", ">= 7.2"
-  s.add_dependency "activesupport", ">= 7.2"
+  s.add_dependency "activerecord", ">= 8.0"
+  s.add_dependency "activesupport", ">= 8.0"
 
   s.required_ruby_version = ">= 3.3"
 end

--- a/spec/lib/pg_search_spec.rb
+++ b/spec/lib/pg_search_spec.rb
@@ -2,17 +2,6 @@
 
 require "spec_helper"
 
-# For Active Record 5.x, the association reflection's cache needs be cleared
-# because we're stubbing the related constants.
-if ActiveRecord::VERSION::MAJOR == 5
-  def clear_searchable_cache
-    PgSearch::Document.reflect_on_association(:searchable).clear_association_scope_cache
-  end
-else
-  def clear_searchable_cache
-  end
-end
-
 # standard:disable RSpec/NestedGroups
 describe PgSearch do
   describe ".multisearch" do
@@ -32,10 +21,7 @@ describe PgSearch do
     end
 
     context "with PgSearch.multisearch_options set to a Hash" do
-      subject do
-        clear_searchable_cache
-        described_class.multisearch(query).map(&:searchable)
-      end
+      subject { described_class.multisearch(query).map(&:searchable) }
 
       before { allow(described_class).to receive(:multisearch_options).and_return(using: :dmetaphone) }
 
@@ -57,10 +43,7 @@ describe PgSearch do
     end
 
     context "with PgSearch.multisearch_options set to a Proc" do
-      subject do
-        clear_searchable_cache
-        described_class.multisearch(query, soundalike).map(&:searchable)
-      end
+      subject { described_class.multisearch(query, soundalike).map(&:searchable) }
 
       before do
         allow(described_class).to receive(:multisearch_options) do
@@ -169,7 +152,6 @@ describe PgSearch do
 
           PgSearch::Multisearch.rebuild(SearchableSubclassModel)
 
-          clear_searchable_cache
           expect(PgSearch::Document.count).to be 1
           expect(PgSearch::Document.first.searchable.class).to be SearchableSubclassModel
           expect(PgSearch::Document.first.searchable).to eq expected
@@ -184,7 +166,6 @@ describe PgSearch do
           PgSearch::Multisearch.rebuild(SearchableSubclassModel)
           expect(PgSearch::Document.count).to be 2
 
-          clear_searchable_cache
           classes = PgSearch::Document.all.collect { |d| d.searchable.class }
           expect(classes).to include SearchableSubclassModel
           expect(classes).to include AnotherSearchableSubclassModel


### PR DESCRIPTION
## Summary

Active Record 7.2 reached end of life on 2026-08-09. Raise the supported floor to Active Record 8.0 and remove its release and stable CI coverage.

- Remove obsolete Arel OR, migration-generator, and Rails 5 spec-cache compatibility paths.
- Align the gemspec, Standard Rails target, README, changelog, and contribution example with the 8.0 floor.

## Test plan

- [x] `mise x -- bin/rake` (Active Record 8.1.3.1)
- [x] `ACTIVE_RECORD_VERSION="~> 8.0.0" mise x -- bundle install && ACTIVE_RECORD_VERSION="~> 8.0.0" mise x -- bin/rake` (Active Record 8.0.5.1)
- [x] `mise x -- bin/standardrb`
- [x] Parsed `.github/workflows/ci.yml` and ran `git diff --check`