### PR TITLE
Expose composable Arel column expressions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,5 +7,4 @@
 /pkg/*
 /tmp/
 Gemfile.lock
-doc
 tags

--- a/doc/plans/2026-09-05-arel-stack.md
+++ b/doc/plans/2026-09-05-arel-stack.md
@@ -1,0 +1,43 @@
+# Incremental Arel migration
+
+Replace useful SQL-string construction with composable Arel expressions in five
+small, independently mergeable changes. Complete elimination of interpolation is
+not required. Each change includes its own caller adaptations and tests; no later
+change should be needed to make an earlier one work.
+
+Use `to_arel` for expressions and `to_sql` for rendered SQL strings. Keep behavior
+unchanged, including trusted SQL expressions and custom ordering. Preserve the
+existing rank-join alias handling. Prefer named immutable values (`Data.define`)
+for structured records, while retaining arrays for genuine expression lists.
+
+## Review and test each layer
+
+Before changing code, assess existing coverage and characterize the relevant
+behavior. Demonstrate failing coverage for new contracts or missing regressions,
+then implement the narrow change. Test SQL execution against PostgreSQL, not just
+rendered strings. Run focused examples, the full suite, and Standard for every
+layer. Review correctness, coverage quality, and unnecessary complexity before
+publishing it.
+
+Exercise expression behavior through `to_arel`. Keep `to_sql` coverage focused on
+its rendering-adapter contract, so eventually removing it does not discard the
+behavioral coverage or require duplicating that coverage across both interfaces.
+
+- [x] **Column expressions:** add explicit Arel conversions for normal and foreign
+  columns, preserving string conversions. Cover NULLs, casts, quoted identifiers,
+  and trusted JSON expressions.
+- [ ] **Association queries:** build aggregated projections and joins with Arel.
+  Cover association types, missing associations, aggregation, and alias collisions.
+- [ ] **Rank selection and ordering:** convert projections and ordering without
+  replacing the existing rank-join fix. Cover selected ranks, tie-breaking,
+  custom ordering, associations, and chained scopes.
+- [ ] **Feature expressions and normalization:** compose search expressions as
+  nodes while preserving sanitization. Cover blank queries, quotes and accents,
+  prefix/negation, weighted and stored vectors, highlighting, and other features.
+- [ ] **Multisearch rebuilds:** convert useful statement components without forcing
+  every fixed SQL fragment into Arel. Cover actual rebuilds, STI, NULL content,
+  multiple columns, and custom identifiers.
+
+Record remaining interpolation after the stack as deferred work, not a release
+gate. Keep unrelated cleanup, historical planning artifacts, and obsolete
+compatibility code out of these changes.

--- a/lib/pg_search/configuration/column.rb
+++ b/lib/pg_search/configuration/column.rb
@@ -21,23 +21,29 @@ module PgSearch
         "#{table_name}.#{column_name}"
       end
 
-      def to_sql
-        "coalesce((#{expression})::text, '')"
-      end
+      def to_arel = coalesce_to_blank_string(cast_to_text(attribute))
+
+      def to_sql = @connection.visitor.compile(to_arel)
 
       private
 
-      def table_name
-        @model.quoted_table_name
+      def attribute
+        return @column_name if @column_name.is_a?(Arel::Nodes::SqlLiteral)
+
+        @model.arel_table[@name]
       end
 
-      def column_name
-        @connection.quote_column_name(@name)
+      def cast_to_text(node)
+        Arel::Nodes::NamedFunction.new("cast", [node.as(Arel.sql("text"))])
       end
 
-      def expression
-        full_name
+      def coalesce_to_blank_string(node)
+        Arel::Nodes::NamedFunction.new("coalesce", [node, Arel.sql("''")])
       end
+
+      def table_name = @model.quoted_table_name
+
+      def column_name = @connection.quote_column_name(@name)
     end
   end
 end

--- a/lib/pg_search/configuration/foreign_column.rb
+++ b/lib/pg_search/configuration/foreign_column.rb
@@ -18,8 +18,8 @@ module PgSearch
 
       private
 
-      def expression
-        "#{@association.subselect_alias}.#{self.alias}"
+      def attribute
+        @model.arel_table.alias(@association.subselect_alias)[self.alias]
       end
 
       def table_name

--- a/spec/lib/pg_search/configuration/column_spec.rb
+++ b/spec/lib/pg_search/configuration/column_spec.rb
@@ -22,22 +22,97 @@ describe PgSearch::Configuration::Column do
     end
   end
 
-  describe "#to_sql" do
+  describe "#to_arel" do
     with_model :Model do
       table do |t|
         t.string :name
+        t.integer :count
         t.json :object
       end
     end
 
-    it "returns an expression that casts the column to text and coalesces it with an empty string" do
+    it "coalesces NULL values to an empty string when composed into a query" do
+      model = Model.create!(name: nil)
       column = described_class.new("name", nil, Model)
-      expect(column.to_sql).to eq(%{coalesce((#{Model.quoted_table_name}."name")::text, '')})
+      query = Model.arel_table
+        .project(column.to_arel.as("value"))
+        .where(Model.arel_table[:id].eq(model.id))
+
+      sql = Model.connection.visitor.compile(query.ast)
+      expect(Model.connection.select_value(sql)).to eq("")
     end
 
-    it "returns an expression that casts the nested json attribute to text and coalesces it with an empty string" do
+    it "casts a non-text column to text when composed into a query" do
+      model = Model.create!(count: 42)
+      column = described_class.new("count", nil, Model)
+      query = Model.arel_table
+        .project(column.to_arel.as("value"))
+        .where(Model.arel_table[:id].eq(model.id))
+
+      sql = Model.connection.visitor.compile(query.ast)
+      expect(Model.connection.select_value(sql)).to eq("42")
+    end
+
+    it "evaluates a trusted SQL literal JSON expression when composed into a query" do
+      model = Model.create!(object: {name: "hello world"})
       column = described_class.new(Arel.sql("object->>'name'"), nil, Model)
-      expect(column.to_sql).to eq(%{coalesce((object->>'name')::text, '')})
+      query = Model.arel_table
+        .project(column.to_arel.as("value"))
+        .where(Model.arel_table[:id].eq(model.id))
+
+      sql = Model.connection.visitor.compile(query.ast)
+      expect(Model.connection.select_value(sql)).to eq("hello world")
+    end
+
+    context "with quoted identifiers" do
+      with_model :QuotedModel do
+        table do |t|
+          t.string "select"
+          t.string "order"
+        end
+      end
+
+      it "executes a reserved-word column through a projected Arel node" do
+        model = QuotedModel.create!(select: "value1")
+        column = described_class.new("select", nil, QuotedModel)
+        query = QuotedModel.arel_table
+          .project(column.to_arel.as("value"))
+          .where(QuotedModel.arel_table[:id].eq(model.id))
+
+        sql = QuotedModel.connection.visitor.compile(query.ast)
+        expect(QuotedModel.connection.select_value(sql)).to eq("value1")
+      end
+
+      it "composes multiple quoted column nodes before execution" do
+        model = QuotedModel.create!(select: "abc", order: "def")
+        select_column = described_class.new("select", nil, QuotedModel)
+        order_column = described_class.new("order", nil, QuotedModel)
+        combined = Arel::Nodes::NamedFunction.new(
+          "concat",
+          [select_column.to_arel, order_column.to_arel]
+        )
+        query = QuotedModel.arel_table
+          .project(combined.as("value"))
+          .where(QuotedModel.arel_table[:id].eq(model.id))
+
+        sql = QuotedModel.connection.visitor.compile(query.ast)
+        expect(QuotedModel.connection.select_value(sql)).to eq("abcdef")
+      end
+    end
+  end
+
+  describe "#to_sql" do
+    with_model :Model do
+      table do |t|
+        t.string :name
+      end
+    end
+
+    it "uses the model connection's visitor as a String adapter" do
+      column = described_class.new("name", nil, Model)
+
+      expect(column.to_sql).to be_a(String)
+      expect(column.to_sql).to eq(Model.connection.visitor.compile(column.to_arel))
     end
   end
 end

--- a/spec/lib/pg_search/configuration/foreign_column_spec.rb
+++ b/spec/lib/pg_search/configuration/foreign_column_spec.rb
@@ -3,37 +3,87 @@
 require "spec_helper"
 
 describe PgSearch::Configuration::ForeignColumn do
+  with_model :AssociatedModel do
+    table do |t|
+      t.string :title
+    end
+  end
+
+  with_model :Model do
+    table do |t|
+      t.string :name
+      t.belongs_to :associated_model, index: false, null: true
+    end
+
+    model do
+      include PgSearch::Model
+
+      belongs_to :associated_model, class_name: "AssociatedModel", optional: true
+
+      pg_search_scope :with_title, associated_against: {associated_model: :title}
+    end
+  end
+
+  let(:association) do
+    PgSearch::Configuration::Association.new(Model, :associated_model, :title)
+  end
+  let(:foreign_column) { described_class.new("title", nil, Model, association) }
+
   describe "#alias" do
-    with_model :AssociatedModel do
-      table do |t|
-        t.string "title"
-      end
-    end
-
-    with_model :Model do
-      table do |t|
-        t.string "title"
-        t.belongs_to :another_model, index: false
-      end
-
-      model do
-        include PgSearch::Model
-
-        belongs_to :another_model, class_name: "AssociatedModel"
-
-        pg_search_scope :with_another, associated_against: {another_model: :title}
-      end
-    end
-
     it "returns a consistent string" do
-      association = PgSearch::Configuration::Association.new(Model,
-        :another_model,
-        :title)
-      foreign_column = described_class.new("title", nil, Model, association)
-
       column_alias = foreign_column.alias
       expect(column_alias).to be_a String
       expect(foreign_column.alias).to eq column_alias
+    end
+  end
+
+  describe "#full_name" do
+    it "returns the fully-qualified associated table and column name" do
+      expect(foreign_column.full_name).to eq(
+        %(#{AssociatedModel.quoted_table_name}."title")
+      )
+    end
+  end
+
+  describe "#to_arel" do
+    def selected_value(model)
+      primary_key = Model.connection.visitor.compile(Model.arel_table[:id])
+      relation = Model
+        .joins(association.join(primary_key))
+        .where(Model.arel_table[:id].eq(model.id))
+        .select(foreign_column.to_arel.as("value"))
+      sql = Model.connection.visitor.compile(relation.arel.ast)
+
+      Model.connection.select_value(sql)
+    end
+
+    it "evaluates the associated value through the association join alias" do
+      associated = AssociatedModel.create!(title: "hello world")
+      model = Model.create!(name: "example", associated_model: associated)
+
+      expect(selected_value(model)).to eq("hello world")
+    end
+
+    it "coalesces a NULL associated value through the association join alias" do
+      associated = AssociatedModel.create!(title: nil)
+      model = Model.create!(name: "example", associated_model: associated)
+
+      expect(selected_value(model)).to eq("")
+    end
+
+    it "coalesces a missing association through the outer join alias" do
+      model = Model.create!(name: "example", associated_model: nil)
+
+      expect(selected_value(model)).to eq("")
+    end
+  end
+
+  describe "#to_sql" do
+    it "uses the model connection's visitor as a String adapter" do
+      expect(foreign_column.to_sql).to be_a(String)
+      expect(foreign_column.to_sql).to eq(
+        Model.connection.visitor.compile(foreign_column.to_arel)
+      )
     end
   end
 end

--- a/spec/lib/pg_search/features/dmetaphone_spec.rb
+++ b/spec/lib/pg_search/features/dmetaphone_spec.rb
@@ -23,7 +23,7 @@ describe PgSearch::Features::DMetaphone do
 
       feature = described_class.new(query, options, columns, Model, normalizer)
       expect(feature.rank.to_sql).to eq(
-        %{(ts_rank((to_tsvector('simple', pg_search_dmetaphone(coalesce((#{Model.quoted_table_name}."name")::text, ''))) || to_tsvector('simple', pg_search_dmetaphone(coalesce((#{Model.quoted_table_name}."content")::text, '')))), (to_tsquery('simple', ''' ' || pg_search_dmetaphone('query') || ' ''')), 0))}
+        %{(ts_rank((to_tsvector('simple', pg_search_dmetaphone(coalesce(cast(#{Model.quoted_table_name}."name" AS text), ''))) || to_tsvector('simple', pg_search_dmetaphone(coalesce(cast(#{Model.quoted_table_name}."content" AS text), '')))), (to_tsquery('simple', ''' ' || pg_search_dmetaphone('query') || ' ''')), 0))}
       )
     end
   end
@@ -48,7 +48,7 @@ describe PgSearch::Features::DMetaphone do
 
       feature = described_class.new(query, options, columns, Model, normalizer)
       expect(feature.conditions.to_sql).to eq(
-        %{((to_tsvector('simple', pg_search_dmetaphone(coalesce((#{Model.quoted_table_name}."name")::text, ''))) || to_tsvector('simple', pg_search_dmetaphone(coalesce((#{Model.quoted_table_name}."content")::text, '')))) @@ (to_tsquery('simple', ''' ' || pg_search_dmetaphone('query') || ' ''')))}
+        %{((to_tsvector('simple', pg_search_dmetaphone(coalesce(cast(#{Model.quoted_table_name}."name" AS text), ''))) || to_tsvector('simple', pg_search_dmetaphone(coalesce(cast(#{Model.quoted_table_name}."content" AS text), '')))) @@ (to_tsquery('simple', ''' ' || pg_search_dmetaphone('query') || ' ''')))}
       )
     end
   end

--- a/spec/lib/pg_search/features/trigram_spec.rb
+++ b/spec/lib/pg_search/features/trigram_spec.rb
@@ -20,9 +20,9 @@ describe PgSearch::Features::Trigram do
 
   let(:coalesced_columns) do
     <<~SQL.squish
-      coalesce((#{Model.quoted_table_name}."name")::text, '')
+      coalesce(cast(#{Model.quoted_table_name}."name" AS text), '')
         || ' '
-        || coalesce((#{Model.quoted_table_name}."content")::text, '')
+        || coalesce(cast(#{Model.quoted_table_name}."content" AS text), '')
     SQL
   end
 
@@ -87,7 +87,7 @@ describe PgSearch::Features::Trigram do
         let(:options) { {only: :name} }
 
         it "only searches against the select column" do
-          coalesced_column = "coalesce((#{Model.quoted_table_name}.\"name\")::text, '')"
+          coalesced_column = "coalesce(cast(#{Model.quoted_table_name}.\"name\" AS text), '')"
           expect(feature.conditions.to_sql).to eq("('#{query}' % (#{coalesced_column}))")
         end
       end

--- a/spec/lib/pg_search/features/tsearch_spec.rb
+++ b/spec/lib/pg_search/features/tsearch_spec.rb
@@ -24,7 +24,7 @@ describe PgSearch::Features::TSearch do
 
       feature = described_class.new(query, options, columns, Model, normalizer)
       expect(feature.rank.to_sql).to eq(
-        %{(ts_rank((to_tsvector('simple', coalesce((#{Model.quoted_table_name}."name")::text, '')) || to_tsvector('simple', coalesce((#{Model.quoted_table_name}."content")::text, ''))), (to_tsquery('simple', ''' ' || 'query' || ' ''')), 0))}
+        %{(ts_rank((to_tsvector('simple', coalesce(cast(#{Model.quoted_table_name}."name" AS text), '')) || to_tsvector('simple', coalesce(cast(#{Model.quoted_table_name}."content" AS text), ''))), (to_tsquery('simple', ''' ' || 'query' || ' ''')), 0))}
       )
     end
 
@@ -67,7 +67,7 @@ describe PgSearch::Features::TSearch do
 
       feature = described_class.new(query, options, columns, Model, normalizer)
       expect(feature.conditions.to_sql).to eq(
-        %{((to_tsvector('simple', coalesce((#{Model.quoted_table_name}."name")::text, '')) || to_tsvector('simple', coalesce((#{Model.quoted_table_name}."content")::text, ''))) @@ (to_tsquery('simple', ''' ' || 'query' || ' ''')))}
+        %{((to_tsvector('simple', coalesce(cast(#{Model.quoted_table_name}."name" AS text), '')) || to_tsvector('simple', coalesce(cast(#{Model.quoted_table_name}."content" AS text), ''))) @@ (to_tsquery('simple', ''' ' || 'query' || ' ''')))}
       )
     end
 
@@ -84,7 +84,7 @@ describe PgSearch::Features::TSearch do
 
         feature = described_class.new(query, options, columns, Model, normalizer)
         expect(feature.conditions.to_sql).to eq(
-          %{((to_tsvector('simple', coalesce((#{Model.quoted_table_name}."name")::text, '')) || to_tsvector('simple', coalesce((#{Model.quoted_table_name}."content")::text, ''))) @@ (to_tsquery('simple', '!' || ''' ' || 'query' || ' ''')))}
+          %{((to_tsvector('simple', coalesce(cast(#{Model.quoted_table_name}."name" AS text), '')) || to_tsvector('simple', coalesce(cast(#{Model.quoted_table_name}."content" AS text), ''))) @@ (to_tsquery('simple', '!' || ''' ' || 'query' || ' ''')))}
         )
       end
     end
@@ -102,7 +102,7 @@ describe PgSearch::Features::TSearch do
 
         feature = described_class.new(query, options, columns, Model, normalizer)
         expect(feature.conditions.to_sql).to eq(
-          %{((to_tsvector('simple', coalesce((#{Model.quoted_table_name}."name")::text, '')) || to_tsvector('simple', coalesce((#{Model.quoted_table_name}."content")::text, ''))) @@ (to_tsquery('simple', ''' ' || '!query' || ' ''')))}
+          %{((to_tsvector('simple', coalesce(cast(#{Model.quoted_table_name}."name" AS text), '')) || to_tsvector('simple', coalesce(cast(#{Model.quoted_table_name}."content" AS text), ''))) @@ (to_tsquery('simple', ''' ' || '!query' || ' ''')))}
         )
       end
     end
@@ -164,7 +164,7 @@ describe PgSearch::Features::TSearch do
 
       feature = described_class.new(query, options, columns, Model, normalizer)
       expect(feature.highlight.to_sql).to eq(
-        "(ts_headline('simple', (coalesce((#{Model.quoted_table_name}.\"name\")::text, '')), (to_tsquery('simple', ''' ' || 'query' || ' ''')), ''))"
+        "(ts_headline('simple', (coalesce(cast(#{Model.quoted_table_name}.\"name\" AS text), '')), (to_tsquery('simple', ''' ' || 'query' || ' ''')), ''))"
       )
     end
 
@@ -189,7 +189,7 @@ describe PgSearch::Features::TSearch do
 
         feature = described_class.new(query, options, columns, Model, normalizer)
 
-        expected_sql = %{(ts_headline('spanish', (coalesce((#{Model.quoted_table_name}."name")::text, '') || ' ' || coalesce((#{Model.quoted_table_name}."content")::text, '')), (to_tsquery('spanish', ''' ' || 'query' || ' ''')), 'StartSel = "<b>", StopSel = "</b>"'))}
+        expected_sql = %{(ts_headline('spanish', (coalesce(cast(#{Model.quoted_table_name}."name" AS text), '') || ' ' || coalesce(cast(#{Model.quoted_table_name}."content" AS text), '')), (to_tsquery('spanish', ''' ' || 'query' || ' ''')), 'StartSel = "<b>", StopSel = "</b>"'))}
 
         expect(feature.highlight.to_sql).to eq(expected_sql)
       end
@@ -221,7 +221,7 @@ describe PgSearch::Features::TSearch do
 
         feature = described_class.new(query, options, columns, Model, normalizer)
 
-        expected_sql = %{(ts_headline('simple', (coalesce((#{Model.quoted_table_name}."name")::text, '')), (to_tsquery('simple', ''' ' || 'query' || ' ''')), 'StartSel = "<start class=""search"">", StopSel = "<stop>", MaxFragments = 3, MaxWords = 123, MinWords = 456, ShortWord = 4, FragmentDelimiter = "&hellip;", HighlightAll = TRUE'))}
+        expected_sql = %{(ts_headline('simple', (coalesce(cast(#{Model.quoted_table_name}."name" AS text), '')), (to_tsquery('simple', ''' ' || 'query' || ' ''')), 'StartSel = "<start class=""search"">", StopSel = "<stop>", MaxFragments = 3, MaxWords = 123, MinWords = 456, ShortWord = 4, FragmentDelimiter = "&hellip;", HighlightAll = TRUE'))}
 
         expect(feature.highlight.to_sql).to eq(expected_sql)
       end
@@ -252,7 +252,7 @@ describe PgSearch::Features::TSearch do
         feature = described_class.new(query, options, columns, Model, normalizer)
 
         highlight_sql = silence_warnings { feature.highlight.to_sql }
-        expected_sql = %{(ts_headline('simple', (coalesce((#{Model.quoted_table_name}."name")::text, '')), (to_tsquery('simple', ''' ' || 'query' || ' ''')), 'StartSel = "<start class=""search"">", StopSel = "<stop>", MaxFragments = 3, MaxWords = 123, MinWords = 456, ShortWord = 4, FragmentDelimiter = "&hellip;", HighlightAll = FALSE'))}
+        expected_sql = %{(ts_headline('simple', (coalesce(cast(#{Model.quoted_table_name}."name" AS text), '')), (to_tsquery('simple', ''' ' || 'query' || ' ''')), 'StartSel = "<start class=""search"">", StopSel = "<stop>", MaxFragments = 3, MaxWords = 123, MinWords = 456, ShortWord = 4, FragmentDelimiter = "&hellip;", HighlightAll = FALSE'))}
 
         expect(highlight_sql).to eq(expected_sql)
       end


### PR DESCRIPTION
Column expressions currently become SQL strings before other query builders can compose them. Add `Column#to_arel` and `ForeignColumn#to_arel` to expose composable expressions while keeping `to_sql` as the rendered-string interface.

The expressions preserve text casting, NULL coalescing, trusted SQL literals, and association aliases. Database-backed coverage exercises those behaviors and composition with quoted identifiers; existing feature expectations follow the equivalent `cast(... AS text)` spelling.

This is the first layer of an incremental Arel migration. It stands on its own: existing callers continue using `to_sql`, and no later layer is required. The checked-in plan describes the remaining layers without requiring complete elimination of SQL interpolation.
