### PR TITLE
Build association search queries with Arel

### DIFF
--- a/doc/plans/2026-09-05-arel-stack.md
+++ b/doc/plans/2026-09-05-arel-stack.md
@@ -26,7 +26,7 @@ behavioral coverage or require duplicating that coverage across both interfaces.
 - [x] **Column expressions:** add explicit Arel conversions for normal and foreign
   columns, preserving string conversions. Cover NULLs, casts, quoted identifiers,
   and trusted JSON expressions.
-- [ ] **Association queries:** build aggregated projections and joins with Arel.
+- [x] **Association queries:** build aggregated projections and joins with Arel.
   Cover association types, missing associations, aggregation, and alias collisions.
 - [ ] **Rank selection and ordering:** convert projections and ordering without
   replacing the existing rank-join fix. Cover selected ranks, tie-breaking,

--- a/lib/pg_search/configuration/association.rb
+++ b/lib/pg_search/configuration/association.rb
@@ -20,7 +20,12 @@ module PgSearch
       end
 
       def join(primary_key)
-        "LEFT OUTER JOIN (#{relation(primary_key).to_sql}) #{subselect_alias} ON #{subselect_alias}.id = #{primary_key}"
+        subquery = relation(primary_key).arel.as(subselect_alias)
+        on_condition = Arel::Nodes::On.new(
+          subquery[:id].eq(Arel.sql(primary_key))
+        )
+        node = Arel::Nodes::OuterJoin.new(subquery, on_condition)
+        @model.connection.unprepared_statement { @model.connection.to_sql(node) }
       end
 
       def subselect_alias
@@ -29,30 +34,31 @@ module PgSearch
 
       private
 
-      def selects
-        if singular_association?
-          selects_for_singular_association
-        else
-          selects_for_multiple_association
-        end
-      end
-
-      def selects_for_singular_association
-        columns.map do |column|
-          "#{column.full_name}::text AS #{column.alias}"
-        end.join(", ")
-      end
-
-      def selects_for_multiple_association
-        columns.map do |column|
-          "string_agg(#{column.full_name}::text, ' ') AS #{column.alias}"
-        end.join(", ")
-      end
-
       def relation(primary_key)
-        result = @model.unscoped.joins(@name).select("#{primary_key} AS id, #{selects}")
+        result = @model.unscoped.joins(@name).select(
+          Arel.sql(primary_key).as("id"),
+          *selects
+        )
         result = result.group(primary_key) unless singular_association?
         result
+      end
+
+      def selects
+        columns.map do |column|
+          cast_node = Arel::Nodes::NamedFunction.new(
+            "cast",
+            [Arel.sql(column.full_name).as(Arel.sql("text"))]
+          )
+          projection = if singular_association?
+            cast_node
+          else
+            Arel::Nodes::NamedFunction.new(
+              "string_agg",
+              [cast_node, Arel::Nodes.build_quoted(" ")]
+            )
+          end
+          projection.as(column.alias)
+        end
       end
 
       def singular_association?

--- a/spec/integration/associations_spec.rb
+++ b/spec/integration/associations_spec.rb
@@ -145,6 +145,57 @@ describe "a pg_search_scope" do
       end
     end
 
+    context "via a scoped has_many association with a quoted literal condition" do
+      with_model :Book do
+        table do |t|
+          t.string "title"
+          t.string "author"
+          t.belongs_to :shelf
+        end
+
+        model do
+          belongs_to :shelf
+        end
+      end
+
+      with_model :Shelf do
+        table do |t|
+          t.string "title"
+        end
+
+        model do
+          include PgSearch::Model
+
+          has_many :obrien_books,
+            -> { where(author: "O'Brien") },
+            class_name: "Book"
+
+          pg_search_scope :with_obrien_books,
+            associated_against: {obrien_books: :title}
+        end
+      end
+
+      it "applies the association condition and handles single-quoted values without bind placeholders" do
+        shelf_with_obrien = Shelf.create!(title: "Main Shelf")
+        shelf_without_obrien = Shelf.create!(title: "Other Shelf")
+
+        Book.create!(
+          title: "The Third Policeman",
+          author: "O'Brien",
+          shelf: shelf_with_obrien
+        )
+        Book.create!(
+          title: "The Third Policeman",
+          author: "Someone Else",
+          shelf: shelf_without_obrien
+        )
+
+        results = Shelf.with_obrien_books("Third Policeman")
+        expect(results).to include(shelf_with_obrien)
+        expect(results).not_to include(shelf_without_obrien)
+      end
+    end
+
     context "when across multiple associations" do
       context "when on different tables" do
         with_model :FirstAssociatedModel do

--- a/spec/lib/pg_search/configuration/association_spec.rb
+++ b/spec/lib/pg_search/configuration/association_spec.rb
@@ -20,7 +20,7 @@ describe PgSearch::Configuration::Association do
     model do
       include PgSearch::Model
 
-      has_one :avatar, class_name: "Avatar"
+      has_one :avatar
       belongs_to :site
 
       pg_search_scope :with_avatar, associated_against: {avatar: :url}
@@ -36,7 +36,7 @@ describe PgSearch::Configuration::Association do
     model do
       include PgSearch::Model
 
-      has_many :users, class_name: "User"
+      has_many :users
 
       pg_search_scope :with_users, associated_against: {users: :name}
     end
@@ -60,11 +60,11 @@ describe PgSearch::Configuration::Association do
             FROM "#{User.table_name}"
             INNER JOIN "#{association.table_name}"
             ON "#{association.table_name}"."user_id" = "#{User.table_name}"."id") #{association.subselect_alias}
-          ON #{association.subselect_alias}.id = model_id
+          ON #{association.subselect_alias}."id" = model_id
         SQL
       end
       let(:column_select) do
-        "\"#{association.table_name}\".\"url\"::text"
+        "cast(\"#{association.table_name}\".\"url\" AS text)"
       end
 
       it "returns the correct SQL join" do
@@ -91,11 +91,11 @@ describe PgSearch::Configuration::Association do
             FROM "#{User.table_name}"
             INNER JOIN "#{association.table_name}"
             ON "#{association.table_name}"."id" = "#{User.table_name}"."site_id") #{association.subselect_alias}
-          ON #{association.subselect_alias}.id = model_id
+          ON #{association.subselect_alias}."id" = model_id
         SQL
       end
       let(:column_select) do
-        "\"#{association.table_name}\".\"title\"::text"
+        "cast(\"#{association.table_name}\".\"title\" AS text)"
       end
 
       it "returns the correct SQL join" do
@@ -118,17 +118,49 @@ describe PgSearch::Configuration::Association do
         <<~SQL.squish
           LEFT OUTER JOIN
             (SELECT model_id AS id,
-                    string_agg("#{association.table_name}"."name"::text, ' ') AS #{association.columns.first.alias}
+                    string_agg(cast("#{association.table_name}"."name" AS text), ' ') AS #{association.columns.first.alias}
             FROM "#{Site.table_name}"
             INNER JOIN "#{association.table_name}"
             ON "#{association.table_name}"."site_id" = "#{Site.table_name}"."id"
             GROUP BY model_id) #{association.subselect_alias}
-          ON #{association.subselect_alias}.id = model_id
+          ON #{association.subselect_alias}."id" = model_id
         SQL
       end
 
       it "returns the correct SQL join" do
         expect(association.join("model_id")).to eq(expected_sql)
+      end
+
+      let(:projected_column) do
+        Arel.sql("#{association.subselect_alias}.#{association.columns.first.alias}")
+      end
+      let(:joined_sites) do
+        primary_key = Site.connection.visitor.compile(Site.arel_table[:id])
+        Site.joins(association.join(primary_key))
+      end
+
+      it "ignores NULL inputs without padding the aggregate" do
+        site = Site.create!
+        site.users.create!(name: nil)
+        site.users.create!(name: "visible")
+        site.users.create!(name: nil)
+
+        expect(joined_sites.pluck(projected_column)).to eq ["visible"]
+      end
+
+      it "preserves an all-NULL aggregate" do
+        site = Site.create!
+        site.users.create!(name: nil)
+        site.users.create!(name: nil)
+
+        expect(joined_sites.pluck(projected_column)).to eq [nil]
+      end
+
+      it "retains the parent when no associated rows exist" do
+        site = Site.create!
+
+        expect(joined_sites.pluck(Site.arel_table[:id])).to eq [site.id]
+        expect(joined_sites.pluck(projected_column)).to eq [nil]
       end
 
       describe "#subselect_alias" do


### PR DESCRIPTION
Build association search projections and outer joins with Arel nodes instead of assembling SQL fragments. This continues the column-expression work in #581.

The existing `join(primary_key)` interface still returns a SQL string. Rendering follows Active Record's unprepared SQL path so conditions on scoped associations keep their bind values, including quoted strings.

Preserve PostgreSQL's aggregation behavior: `string_agg` skips NULL inputs without adding padding, all-NULL groups remain NULL, and the outer join retains records without associated rows. Database-backed coverage exercises those cases and a conditional association.
