### PR TITLE
Compose rank projections and ordering with Arel

### DIFF
--- a/doc/plans/2026-09-05-arel-stack.md
+++ b/doc/plans/2026-09-05-arel-stack.md
@@ -28,7 +28,7 @@ behavioral coverage or require duplicating that coverage across both interfaces.
   and trusted JSON expressions.
 - [x] **Association queries:** build aggregated projections and joins with Arel.
   Cover association types, missing associations, aggregation, and alias collisions.
-- [ ] **Rank selection and ordering:** convert projections and ordering without
+- [x] **Rank selection and ordering:** convert projections and ordering without
   replacing the existing rank-join fix. Cover selected ranks, tie-breaking,
   custom ordering, associations, and chained scopes.
 - [ ] **Feature expressions and normalization:** compose search expressions as

--- a/lib/pg_search/scope_options.rb
+++ b/lib/pg_search/scope_options.rb
@@ -15,10 +15,12 @@ module PgSearch
     def apply(scope)
       scope = include_table_aliasing_for_rank(scope)
       rank_table_alias = scope.pg_search_rank_table_alias(include_counter: true)
+      rank_subquery = subquery.arel.as(rank_table_alias)
 
       scope
-        .joins(rank_join(rank_table_alias))
-        .order(Arel.sql("#{rank_table_alias}.rank DESC, #{order_within_rank}"))
+        .joins(rank_join(rank_subquery))
+        .order(rank_subquery[:rank].desc)
+        .order(order_within_rank)
         .extend(WithPgSearchRank)
         .extend(WithPgSearchHighlight[feature_for(:tsearch)])
     end
@@ -51,7 +53,8 @@ module PgSearch
       def with_pg_search_rank
         scope = self
         scope = scope.select("#{table_name}.*") unless scope.select_values.any?
-        scope.select("#{pg_search_rank_table_alias}.rank AS pg_search_rank")
+        rank_column = Arel.sql("#{pg_search_rank_table_alias}.rank").as("pg_search_rank")
+        scope.select(rank_column)
       end
     end
 
@@ -82,8 +85,8 @@ module PgSearch
     def subquery
       model
         .unscoped
-        .select("#{primary_key} AS pg_search_id")
-        .select("#{rank} AS rank")
+        .select(model.arel_table[model.primary_key].as("pg_search_id"))
+        .select(Arel.sql(rank).as("rank"))
         .joins(subquery_join)
         .where(conditions)
         .limit(nil)
@@ -100,7 +103,11 @@ module PgSearch
     end
 
     def order_within_rank
-      config.order_within_rank || "#{primary_key} ASC"
+      if config.order_within_rank
+        Arel.sql(config.order_within_rank)
+      else
+        model.arel_table[model.primary_key].asc
+      end
     end
 
     def primary_key
@@ -144,13 +151,10 @@ module PgSearch
       end
     end
 
-    def rank_join(rank_table_alias)
-      arel_table = model.arel_table
-      subquery_arel = subquery.arel.as(rank_table_alias)
-
-      arel_table
-        .join(subquery_arel)
-        .on(arel_table[model.primary_key].eq(subquery_arel[:pg_search_id]))
+    def rank_join(rank_subquery)
+      model.arel_table
+        .join(rank_subquery)
+        .on(model.arel_table[model.primary_key].eq(rank_subquery[:pg_search_id]))
         .join_sources
     end
 

--- a/spec/integration/pg_search_spec.rb
+++ b/spec/integration/pg_search_spec.rb
@@ -1228,6 +1228,23 @@ describe "an Active Record model which includes PgSearch" do
       end
     end
 
+    context "when passed an :order_within_rank expression" do
+      before do
+        ModelWithPgSearch.pg_search_scope :search_content_ordered_by_importance,
+          against: :content,
+          order_within_rank: "importance DESC"
+      end
+
+      it "breaks ties in rank by the custom expression" do
+        # Both records match equally; importance determines order
+        low = ModelWithPgSearch.create!(content: "foo", importance: 1)
+        high = ModelWithPgSearch.create!(content: "foo", importance: 5)
+
+        results = ModelWithPgSearch.search_content_ordered_by_importance("foo")
+        expect(results).to eq([high, low])
+      end
+    end
+
     context "when passed a :ranked_by expression" do
       before do
         ModelWithPgSearch.pg_search_scope :search_content_with_default_rank,


### PR DESCRIPTION
Compose rank projections and ordering with Arel rather than combining them into SQL strings.

Reuse the aliased ranking subquery for both the join and descending rank order, preserving the alias handling needed by chained search scopes. Express the default primary-key tie-break as an Arel ordering node while retaining custom `order_within_rank` SQL as a trusted expression.

The existing selected-rank and association behavior stays unchanged. Add database coverage for custom tie-breaking, with equally ranked records whose importance reverses the default order.

Builds on #582; feature-expression conversion remains a separate layer.
