### PR TITLE
Run CI for pull requests targeting any branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,8 +6,6 @@ on:
       - master
       - github-actions
   pull_request:
-    branches:
-      - master
   schedule:
     - cron: "0 18 * * 6" # Saturdays at 12pm CST
   workflow_dispatch:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -15,7 +15,6 @@ on:
   push:
     branches: [ "master" ]
   pull_request:
-    branches: [ "master" ]
   schedule:
     - cron: '28 0 * * 1'
 


### PR DESCRIPTION
Stacked pull requests target another feature branch rather than `master`, so the current base-branch filters silently skip both the test matrix and CodeQL.

Remove those filters from the `pull_request` triggers. Keep the existing push-branch restrictions, schedules, manual test trigger, permissions, and jobs unchanged.
