### PR TITLE
Compose search feature expressions with Arel

### DIFF
--- a/doc/plans/2026-09-05-arel-stack.md
+++ b/doc/plans/2026-09-05-arel-stack.md
@@ -31,7 +31,7 @@ behavioral coverage or require duplicating that coverage across both interfaces.
 - [x] **Rank selection and ordering:** convert projections and ordering without
   replacing the existing rank-join fix. Cover selected ranks, tie-breaking,
   custom ordering, associations, and chained scopes.
-- [ ] **Feature expressions and normalization:** compose search expressions as
+- [x] **Feature expressions and normalization:** compose search expressions as
   nodes while preserving sanitization. Cover blank queries, quotes and accents,
   prefix/negation, weighted and stored vectors, highlighting, and other features.
 - [ ] **Multisearch rebuilds:** convert useful statement components without forcing

--- a/lib/pg_search/features/dmetaphone.rb
+++ b/lib/pg_search/features/dmetaphone.rb
@@ -25,15 +25,11 @@ module PgSearch
           @normalizer_to_wrap = normalizer_to_wrap
         end
 
-        def add_normalization(original_sql)
-          otherwise_normalized_sql = Arel.sql(
-            normalizer_to_wrap.add_normalization(original_sql)
-          )
-
+        def add_normalization(expression)
           Arel::Nodes::NamedFunction.new(
             "pg_search_dmetaphone",
-            [otherwise_normalized_sql]
-          ).to_sql
+            [normalizer_to_wrap.add_normalization(expression)]
+          )
         end
 
         private

--- a/lib/pg_search/features/feature.rb
+++ b/lib/pg_search/features/feature.rb
@@ -25,7 +25,14 @@ module PgSearch
       attr_reader :query, :options, :all_columns, :model, :normalizer
 
       def document
-        columns.map(&:to_sql).join(" || ' ' || ")
+        space = Arel.sql("' '")
+        columns.map(&:to_arel).inject do |memo, col|
+          Arel::Nodes::InfixOperation.new(
+            "||",
+            Arel::Nodes::InfixOperation.new("||", memo, space),
+            col
+          )
+        end
       end
 
       def columns

--- a/lib/pg_search/features/trigram.rb
+++ b/lib/pg_search/features/trigram.rb
@@ -29,43 +29,29 @@ module PgSearch
 
       private
 
-      def word_similarity?
-        options[:word_similarity]
-      end
+      def word_similarity? = options[:word_similarity]
 
       def similarity_function
-        if word_similarity?
-          "word_similarity"
-        else
-          "similarity"
-        end
+        word_similarity? ? "word_similarity" : "similarity"
       end
 
       def infix_operator
-        if word_similarity?
-          "<%"
-        else
-          "%"
-        end
+        word_similarity? ? "<%" : "%"
       end
 
       def similarity
         Arel::Nodes::NamedFunction.new(
           similarity_function,
-          [
-            normalized_query,
-            normalized_document
-          ]
+          [normalized_query, normalized_document]
         )
       end
 
       def normalized_document
-        Arel::Nodes::Grouping.new(Arel.sql(normalize(document)))
+        Arel::Nodes::Grouping.new(normalize(document))
       end
 
       def normalized_query
-        sanitized_query = connection.quote(query)
-        Arel.sql(normalize(sanitized_query))
+        normalize(Arel::Nodes.build_quoted(query))
       end
     end
   end

--- a/lib/pg_search/features/tsearch.rb
+++ b/lib/pg_search/features/tsearch.rb
@@ -12,16 +12,16 @@ module PgSearch
 
       def conditions
         Arel::Nodes::Grouping.new(
-          Arel::Nodes::InfixOperation.new("@@", arel_wrap(tsdocument), arel_wrap(tsquery))
+          Arel::Nodes::InfixOperation.new("@@", Arel::Nodes::Grouping.new(tsdocument), Arel::Nodes::Grouping.new(tsquery))
         )
       end
 
       def rank
-        arel_wrap(tsearch_rank)
+        Arel::Nodes::Grouping.new(tsearch_rank)
       end
 
       def highlight
-        arel_wrap(ts_headline)
+        Arel::Nodes::Grouping.new(ts_headline)
       end
 
       private
@@ -29,10 +29,10 @@ module PgSearch
       def ts_headline
         Arel::Nodes::NamedFunction.new("ts_headline", [
           dictionary,
-          arel_wrap(document),
-          arel_wrap(tsquery),
+          Arel::Nodes::Grouping.new(document),
+          Arel::Nodes::Grouping.new(tsquery),
           Arel::Nodes.build_quoted(ts_headline_options)
-        ]).to_sql
+        ])
       end
 
       def ts_headline_options
@@ -97,22 +97,20 @@ module PgSearch
         end
 
         sanitized_term = unsanitized_term.gsub(DISALLOWED_TSQUERY_CHARACTERS, " ")
+        term_node = normalize(Arel::Nodes.build_quoted(sanitized_term))
+        tsquery_expr = tsquery_expression(term_node, negated: negated, prefix: options[:prefix])
 
-        term_sql = Arel.sql(normalize(connection.quote(sanitized_term)))
-
-        tsquery = tsquery_expression(term_sql, negated: negated, prefix: options[:prefix])
-
-        Arel::Nodes::NamedFunction.new("to_tsquery", [dictionary, tsquery]).to_sql
+        Arel::Nodes::NamedFunction.new("to_tsquery", [dictionary, tsquery_expr])
       end
 
       # After this, the SQL expression evaluates to a string containing the term surrounded by single-quotes.
       # If :prefix is true, then the term will have :* appended to the end.
       # If :negated is true, then the term will have ! prepended to the front.
-      def tsquery_expression(term_sql, negated:, prefix:)
+      def tsquery_expression(term_node, negated:, prefix:)
         terms = [
           (Arel::Nodes.build_quoted("!") if negated),
           Arel::Nodes.build_quoted("' "),
-          term_sql,
+          term_node,
           Arel::Nodes.build_quoted(" '"),
           (Arel::Nodes.build_quoted(":*") if prefix)
         ].compact
@@ -123,29 +121,24 @@ module PgSearch
       end
 
       def tsquery
-        return "''" if query.blank?
+        return Arel.sql("''") if query.blank?
 
         query_terms = query.split.compact
-        tsquery_terms = query_terms.map { |term| tsquery_for_term(term) }
-        tsquery_terms.join(options[:any_word] ? " || " : " && ")
+        query_terms.map { |term| tsquery_for_term(term) }
+          .inject { |memo, t| Arel::Nodes::InfixOperation.new(options[:any_word] ? "||" : "&&", memo, t) }
       end
 
       def tsdocument
-        tsdocument_terms = (columns_to_use || []).map do |search_column|
-          column_to_tsvector(search_column)
-        end
+        terms = (columns_to_use || []).map { |col| column_to_tsvector(col) }
 
         if options[:tsvector_column]
-          tsvector_columns = Array.wrap(options[:tsvector_column])
-
-          tsdocument_terms << tsvector_columns.map do |tsvector_column|
+          Array.wrap(options[:tsvector_column]).each do |tsvector_column|
             column_name = connection.quote_column_name(tsvector_column)
-
-            "#{quoted_table_name}.#{column_name}"
+            terms << Arel.sql("#{quoted_table_name}.#{column_name}")
           end
         end
 
-        tsdocument_terms.join(" || ")
+        terms.inject { |memo, t| Arel::Nodes::InfixOperation.new("||", memo, t) } || Arel.sql("")
       end
 
       # From http://www.postgresql.org/docs/8.3/static/textsearch-controls.html
@@ -163,18 +156,14 @@ module PgSearch
 
       def tsearch_rank
         Arel::Nodes::NamedFunction.new("ts_rank", [
-          arel_wrap(tsdocument),
-          arel_wrap(tsquery),
+          Arel::Nodes::Grouping.new(tsdocument),
+          Arel::Nodes::Grouping.new(tsquery),
           normalization
-        ]).to_sql
+        ])
       end
 
       def dictionary
         Arel::Nodes.build_quoted(options[:dictionary] || :simple)
-      end
-
-      def arel_wrap(sql_string)
-        Arel::Nodes::Grouping.new(Arel.sql(sql_string))
       end
 
       def columns_to_use
@@ -188,13 +177,16 @@ module PgSearch
       def column_to_tsvector(search_column)
         tsvector = Arel::Nodes::NamedFunction.new(
           "to_tsvector",
-          [dictionary, Arel.sql(normalize(search_column.to_sql))]
-        ).to_sql
+          [dictionary, normalize(search_column.to_arel)]
+        )
 
         if search_column.weight.nil?
           tsvector
         else
-          "setweight(#{tsvector}, #{connection.quote(search_column.weight)})"
+          Arel::Nodes::NamedFunction.new(
+            "setweight",
+            [tsvector, Arel::Nodes.build_quoted(search_column.weight)]
+          )
         end
       end
     end

--- a/lib/pg_search/normalizer.rb
+++ b/lib/pg_search/normalizer.rb
@@ -8,32 +8,32 @@ module PgSearch
 
     DISALLOWED_CHARACTERS = "'[''?\\:]'"
 
-    def add_normalization(sql_expression)
-      return sql_expression unless config.ignore.include?(:accents)
-
-      sql_node = case sql_expression
-      when Arel::Nodes::Node
-        sql_expression
-      else
-        Arel.sql(sql_expression)
-      end
+    def add_normalization(expression)
+      node = to_node(expression)
+      return node unless config.ignore.include?(:accents)
 
       Arel::Nodes::NamedFunction.new(
         "regexp_replace",
         [
-          Arel::Nodes::NamedFunction.new(
-            PgSearch.unaccent_function,
-            [sql_node]
-          ),
+          Arel::Nodes::NamedFunction.new(PgSearch.unaccent_function, [node]),
           Arel.sql(DISALLOWED_CHARACTERS),
           Arel.sql("''"),
           Arel.sql("'g'")
         ]
-      ).to_sql
+      )
     end
 
     private
 
     attr_reader :config
+
+    def to_node(expression)
+      case expression
+      when Arel::Nodes::Node
+        expression
+      else
+        Arel.sql(expression.to_s)
+      end
+    end
   end
 end

--- a/spec/lib/pg_search/normalizer_spec.rb
+++ b/spec/lib/pg_search/normalizer_spec.rb
@@ -7,55 +7,81 @@ describe PgSearch::Normalizer do
   describe "#add_normalization" do
     context "when config[:ignore] includes :accents" do
       context "when passed an Arel node" do
-        it "wraps the expression in unaccent()" do
+        it "returns an Arel node wrapping the expression in unaccent()" do
           config = instance_double(PgSearch::Configuration, "config", ignore: [:accents])
           node = Arel::Nodes::NamedFunction.new("foo", [Arel::Nodes.build_quoted("bar")])
 
           normalizer = described_class.new(config)
-          expect(normalizer.add_normalization(node)).to eq("regexp_replace(unaccent(foo('bar')), '[''?\\:]', '', 'g')")
+          result = normalizer.add_normalization(node)
+          expect(result).to be_an(Arel::Nodes::Node)
+          expect(result.to_sql).to eq("regexp_replace(unaccent(foo('bar')), '[''?\\:]', '', 'g')")
         end
 
         context "when a custom unaccent function is specified" do
-          it "wraps the expression in that function" do
+          it "returns an Arel node using that function" do
             allow(PgSearch).to receive(:unaccent_function).and_return("my_unaccent")
             node = Arel::Nodes::NamedFunction.new("foo", [Arel::Nodes.build_quoted("bar")])
 
             config = instance_double(PgSearch::Configuration, "config", ignore: [:accents])
 
             normalizer = described_class.new(config)
-            expect(normalizer.add_normalization(node)).to eq("regexp_replace(my_unaccent(foo('bar')), '[''?\\:]', '', 'g')")
+            result = normalizer.add_normalization(node)
+            expect(result).to be_an(Arel::Nodes::Node)
+            expect(result.to_sql).to eq("regexp_replace(my_unaccent(foo('bar')), '[''?\\:]', '', 'g')")
           end
         end
       end
 
-      context "when passed a String" do
-        it "wraps the expression in unaccent()" do
+      context "when passed a String (trusted SQL expression)" do
+        it "returns an Arel node wrapping the expression in unaccent()" do
           config = instance_double(PgSearch::Configuration, "config", ignore: [:accents])
 
           normalizer = described_class.new(config)
-          expect(normalizer.add_normalization("foo")).to eq("regexp_replace(unaccent(foo), '[''?\\:]', '', 'g')")
+          result = normalizer.add_normalization("foo")
+          expect(result).to be_an(Arel::Nodes::Node)
+          expect(result.to_sql).to eq("regexp_replace(unaccent(foo), '[''?\\:]', '', 'g')")
         end
 
         context "when a custom unaccent function is specified" do
-          it "wraps the expression in that function" do
+          it "returns an Arel node using that function" do
             allow(PgSearch).to receive(:unaccent_function).and_return("my_unaccent")
 
             config = instance_double(PgSearch::Configuration, "config", ignore: [:accents])
 
             normalizer = described_class.new(config)
-            expect(normalizer.add_normalization("foo")).to eq("regexp_replace(my_unaccent(foo), '[''?\\:]', '', 'g')")
+            result = normalizer.add_normalization("foo")
+            expect(result).to be_an(Arel::Nodes::Node)
+            expect(result.to_sql).to eq("regexp_replace(my_unaccent(foo), '[''?\\:]', '', 'g')")
           end
         end
       end
     end
 
     context "when config[:ignore] does not include :accents" do
-      it "passes the expression through" do
+      it "passes the expression through as an Arel-compatible object" do
         config = instance_double(PgSearch::Configuration, "config", ignore: [])
 
         normalizer = described_class.new(config)
-        expect(normalizer.add_normalization("foo")).to eq("foo")
+        result = normalizer.add_normalization("foo")
+        expect(result).to eq("foo")  # SqlLiteral is a String subclass, usable in Arel contexts
       end
+    end
+  end
+
+  describe "executed against PostgreSQL" do
+    with_model :Book do
+      table { |t| t.string :title }
+    end
+
+    it "strips accents from a real column value when ignoring accents" do
+      Book.create!(title: "caf\u00e9")
+      config = instance_double(PgSearch::Configuration, ignore: [:accents])
+      normalizer = described_class.new(config)
+      col = PgSearch::Configuration::Column.new(:title, nil, Book)
+      expr = normalizer.add_normalization(col.to_arel)
+      sql = "SELECT (#{expr.to_sql}) FROM #{Book.quoted_table_name} LIMIT 1"
+      result = ActiveRecord::Base.connection.select_value(sql)
+      expect(result).to eq("cafe")
     end
   end
 end


### PR DESCRIPTION
Keep search expressions composable through normalization and feature construction instead of repeatedly rendering SQL strings and wrapping them back into Arel.

Build documents from `Column#to_arel`, concatenate vectors and queries as expressions, and compose text-search ranks and headlines directly from those nodes. Trigram and double-metaphone normalization consume the same expressions without intermediate rendering.

Query values remain quoted; application-provided SQL expressions remain trusted inputs. The existing sanitization, weighting, accent handling, and combined-feature behavior is preserved.

Existing public-feature tests cover search behavior, with a PostgreSQL-executed example for accent normalization. Document construction no longer depends on the column String-rendering adapter; the helper stays private without a dedicated spec.

Builds on #583. Multisearch rebuilding remains the final separate layer.
