### PR TITLE
Replace remaining query projection interpolation

### DIFF
--- a/doc/plans/2026-09-06-arel-remaining-expressions.md
+++ b/doc/plans/2026-09-06-arel-remaining-expressions.md
@@ -1,0 +1,37 @@
+# Remaining Arel expression construction
+
+Continuation of the approved [Arel stack](2026-09-05-arel-stack.md), authorized
+for autonomous follow-through while the earlier PRs are reviewed. Preserve
+those PR heads; publish new independently green layers above #587.
+
+## Contract
+
+Replace remaining SQL-construction interpolation with composable expressions,
+without changing query behavior or existing String-returning adapter contracts.
+Do not rewrite ordinary messages, generated names, or PostgreSQL headline-option
+data merely to eliminate Ruby interpolation. No new database functions/migrations.
+
+- [x] **Query projections and vectors:** convert ScopeOptions star/highlight/rank
+  projections and qualified primary-key rendering, plus TSearch's stored-vector
+  references. Preserve explicit select behavior, trusted custom SQL, chained
+  aliases, quoted identifiers, and synthetic rank references without accidentally
+  applying model attribute aliases.
+- [ ] **Column source references:** replace full_name interpolation and the
+  aggregate's String-to-Arel round trip with a coherent source-attribute
+  expression. Preserve the distinction between a foreign column's original
+  association source and its derived search-document alias, non-coalesced
+  aggregation, and the existing full_name/to_sql String interfaces.
+- [ ] **Final audit:** verify remaining interpolation is intentional data or
+  trusted escape-hatch serialization; report residue rather than hiding it.
+
+## Verification and delivery
+
+Characterize meaningful missing behavior before refactoring; no private-helper
+specs or test-only visibility subclasses. Simplify touched fixture setup using
+normal schema names and Rails conventions. Prefer public database behavior over
+additional SQL golden matrices. Run relevant specs and bin/rake independently
+for each layer, including the existing pinned Rails-main environment; require
+one focused independent review per layer and green hosted CI.
+
+Check each item with its owning code. Keep an empty working commit above the
+stack. Until /hi, do not sign; record any new unsigned commits for later signing.

--- a/lib/pg_search/features/tsearch.rb
+++ b/lib/pg_search/features/tsearch.rb
@@ -133,8 +133,10 @@ module PgSearch
 
         if options[:tsvector_column]
           Array.wrap(options[:tsvector_column]).each do |tsvector_column|
-            column_name = connection.quote_column_name(tsvector_column)
-            terms << Arel.sql("#{quoted_table_name}.#{column_name}")
+            terms << Arel::Attributes::Attribute.new(
+              model.arel_table,
+              tsvector_column.to_s
+            )
           end
         end
 

--- a/lib/pg_search/scope_options.rb
+++ b/lib/pg_search/scope_options.rb
@@ -40,8 +40,8 @@ module PgSearch
 
       def with_pg_search_highlight
         scope = self
-        scope = scope.select("#{table_name}.*") unless scope.select_values.any?
-        scope.select("(#{highlight}) AS pg_search_highlight")
+        scope = scope.select(arel_table[Arel.star]) if scope.select_values.empty?
+        scope.select(tsearch.highlight.as("pg_search_highlight"))
       end
 
       def highlight
@@ -52,9 +52,10 @@ module PgSearch
     module WithPgSearchRank
       def with_pg_search_rank
         scope = self
-        scope = scope.select("#{table_name}.*") unless scope.select_values.any?
-        rank_column = Arel.sql("#{pg_search_rank_table_alias}.rank").as("pg_search_rank")
-        scope.select(rank_column)
+        scope = scope.select(arel_table[Arel.star]) if scope.select_values.empty?
+        rank_table = arel_table.alias(pg_search_rank_table_alias)
+        rank_column = Arel::Attributes::Attribute.new(rank_table, "rank")
+        scope.select(rank_column.as("pg_search_rank"))
       end
     end
 
@@ -80,7 +81,7 @@ module PgSearch
 
     private
 
-    delegate :connection, :quoted_table_name, to: :model
+    delegate :connection, to: :model
 
     def subquery
       model
@@ -111,7 +112,11 @@ module PgSearch
     end
 
     def primary_key
-      "#{quoted_table_name}.#{connection.quote_column_name(model.primary_key)}"
+      attribute = Arel::Attributes::Attribute.new(
+        model.arel_table,
+        model.primary_key
+      )
+      connection.visitor.compile(attribute)
     end
 
     def subquery_join

--- a/spec/integration/pg_search_spec.rb
+++ b/spec/integration/pg_search_spec.rb
@@ -1112,6 +1112,37 @@ describe "an Active Record model which includes PgSearch" do
       end
     end
 
+    context "with quoted identifiers and a rank attribute alias" do
+      with_model :Article do
+        table primary_key: "ArticleID" do |t|
+          t.text :content
+          t.tsvector "SearchVector"
+          t.integer :importance
+        end
+
+        model do
+          include PgSearch::Model
+
+          alias_attribute :rank, :importance
+          pg_search_scope :search_content,
+            using: {tsearch: {tsvector_column: "SearchVector"}}
+        end
+      end
+
+      it "searches the physical vector and selects the synthetic rank" do
+        article = Article.create!(content: "phooey", importance: 10)
+        Article.update_all(
+          %("SearchVector" = to_tsvector('simple', "content"))
+        )
+
+        result = Article.search_content("phooey").with_pg_search_rank.first
+
+        expect(result).to eq(article)
+        expect(result.pg_search_rank).to be_a(Float)
+        expect(result.pg_search_rank).not_to eq(result.importance)
+      end
+    end
+
     context "when using multiple tsvector columns" do
       with_model :ModelWithTsvector do
         table


### PR DESCRIPTION
Replace the remaining SQL-string construction for query projections and stored-vector references with Arel attributes and aliases.

Default projections still include the model's columns, while explicit selections remain unchanged. Synthetic rank and physical vector references bypass model attribute aliases; qualified primary-key rendering keeps its existing String interface for association joins.

A public search example exercises case-sensitive identifiers and a model attribute alias that must not redirect the computed rank.

This continues above #587 without changing the earlier PRs under review. Column source references remain the next separate layer.
