### PR TITLE
Keep source column references as Arel attributes

### DIFF
--- a/doc/plans/2026-09-06-arel-remaining-expressions.md
+++ b/doc/plans/2026-09-06-arel-remaining-expressions.md
@@ -6,8 +6,9 @@ those PR heads; publish new independently green layers above #587.
 
 ## Contract
 
-Replace remaining SQL-construction interpolation with composable expressions,
-without changing query behavior or existing String-returning adapter contracts.
+Replace remaining SQL-construction interpolation and avoidable raw SQL fragments
+with composable expressions, without changing query behavior or existing
+String-returning adapter contracts.
 Do not rewrite ordinary messages, generated names, or PostgreSQL headline-option
 data merely to eliminate Ruby interpolation. No new database functions/migrations.
 
@@ -16,13 +17,24 @@ data merely to eliminate Ruby interpolation. No new database functions/migration
   references. Preserve explicit select behavior, trusted custom SQL, chained
   aliases, quoted identifiers, and synthetic rank references without accidentally
   applying model attribute aliases.
-- [ ] **Column source references:** replace full_name interpolation and the
+- [x] **Column source references:** replace full_name interpolation and the
   aggregate's String-to-Arel round trip with a coherent source-attribute
   expression. Preserve the distinction between a foreign column's original
   association source and its derived search-document alias, non-coalesced
   aggregation, and the existing full_name/to_sql String interfaces.
-- [ ] **Final audit:** verify remaining interpolation is intentional data or
-  trusted escape-hatch serialization; report residue rather than hiding it.
+- [ ] **Quoted values:** replace hand-quoted data and quote/render/wrap patterns
+  with quoted-value nodes: separators, empty strings, regex arguments, model
+  names, and timestamps. Preserve actual data, escaping, NULL behavior, and the
+  shared timestamp. Do not confuse a SQL type token or empty SQL fragment with
+  a string value.
+- [ ] **Expression boundaries:** preserve Arel attributes through normalization
+  instead of coercing their Ruby inspection into SQL; remove avoidable internal
+  render-and-wrap cycles for primary keys and default ranking. Preserve the
+  documented custom SQL inputs and legacy String adapters at their boundaries.
+  Investigate empty-expression fragments before changing their semantics.
+- [ ] **Final audit:** verify remaining interpolation/raw SQL is intentional
+  syntax, data serialization, or trusted escape-hatch input; report residue
+  rather than hiding it.
 
 ## Verification and delivery
 

--- a/lib/pg_search/configuration/association.rb
+++ b/lib/pg_search/configuration/association.rb
@@ -19,6 +19,8 @@ module PgSearch
         @model.reflect_on_association(@name).table_name
       end
 
+      def arel_table = @model.reflect_on_association(@name).klass.arel_table
+
       def join(primary_key)
         subquery = relation(primary_key).arel.as(subselect_alias)
         on_condition = Arel::Nodes::On.new(
@@ -47,7 +49,7 @@ module PgSearch
         columns.map do |column|
           cast_node = Arel::Nodes::NamedFunction.new(
             "cast",
-            [Arel.sql(column.full_name).as(Arel.sql("text"))]
+            [column.source_attribute.as(Arel.sql("text"))]
           )
           projection = if singular_association?
             cast_node

--- a/lib/pg_search/configuration/column.rb
+++ b/lib/pg_search/configuration/column.rb
@@ -15,10 +15,12 @@ module PgSearch
         @connection = model.connection
       end
 
-      def full_name
+      def full_name = @connection.visitor.compile(source_attribute)
+
+      def source_attribute
         return @column_name if @column_name.is_a?(Arel::Nodes::SqlLiteral)
 
-        "#{table_name}.#{column_name}"
+        Arel::Attributes::Attribute.new(source_table, @name)
       end
 
       def to_arel = coalesce_to_blank_string(cast_to_text(attribute))
@@ -41,9 +43,7 @@ module PgSearch
         Arel::Nodes::NamedFunction.new("coalesce", [node, Arel.sql("''")])
       end
 
-      def table_name = @model.quoted_table_name
-
-      def column_name = @connection.quote_column_name(@name)
+      def source_table = @model.arel_table
     end
   end
 end

--- a/lib/pg_search/configuration/foreign_column.rb
+++ b/lib/pg_search/configuration/foreign_column.rb
@@ -22,9 +22,7 @@ module PgSearch
         @model.arel_table.alias(@association.subselect_alias)[self.alias]
       end
 
-      def table_name
-        @connection.quote_table_name(@association.table_name)
-      end
+      def source_table = @association.arel_table
     end
   end
 end

--- a/spec/integration/associations_spec.rb
+++ b/spec/integration/associations_spec.rb
@@ -196,6 +196,76 @@ describe "a pg_search_scope" do
       end
     end
 
+    context "with a physical source column shadowed by a model alias" do
+      with_model :Book do
+        table do |t|
+          t.string :title
+          t.string :name
+          t.belongs_to :shelf
+        end
+
+        model do
+          belongs_to :shelf
+        end
+      end
+
+      with_model :Shelf do
+        table
+
+        model do
+          include PgSearch::Model
+
+          has_many :books
+
+          pg_search_scope :search, associated_against: {books: :title}
+        end
+      end
+
+      it "searches the physical association source through the derived alias" do
+        shelf = Shelf.create!
+        shelf.books.create!(title: "physical", name: "alias")
+        Book.alias_attribute :title, :name
+
+        expect(Shelf.search("physical")).to eq [shelf]
+        expect(Shelf.search("alias")).to be_empty
+      end
+    end
+
+    context "with a trusted SQL expression as the association source" do
+      with_model :Book do
+        table do |t|
+          t.json :metadata
+          t.belongs_to :shelf
+        end
+
+        model do
+          belongs_to :shelf
+        end
+      end
+
+      with_model :Shelf do
+        table
+
+        model do
+          include PgSearch::Model
+
+          has_many :books
+
+          pg_search_scope :search,
+            associated_against: {books: Arel.sql("metadata->>'title'")}
+        end
+      end
+
+      it "evaluates the expression before aggregating the associated rows" do
+        shelf = Shelf.create!
+        shelf.books.create!(metadata: {title: "Hello"})
+        shelf.books.create!(metadata: {title: "world"})
+
+        expect(Shelf.search("Hello world")).to eq [shelf]
+        expect(Shelf.search("title")).to be_empty
+      end
+    end
+
     context "when across multiple associations" do
       context "when on different tables" do
         with_model :FirstAssociatedModel do

--- a/spec/lib/pg_search/configuration/column_spec.rb
+++ b/spec/lib/pg_search/configuration/column_spec.rb
@@ -101,6 +101,24 @@ describe PgSearch::Configuration::Column do
     end
   end
 
+  context "when a model alias shadows a physical column" do
+    with_model :Book do
+      table do |t|
+        t.string :title
+        t.string :name
+      end
+    end
+
+    it "keeps full_name physical while normalizing the model attribute" do
+      Book.create!(title: "physical", name: "alias")
+      Book.alias_attribute :title, :name
+      column = described_class.new(:title, nil, Book)
+
+      expect(Book.pluck(Arel.sql(column.full_name))).to eq ["physical"]
+      expect(Book.pluck(column.to_arel)).to eq ["alias"]
+    end
+  end
+
   describe "#to_sql" do
     with_model :Model do
       table do |t|


### PR DESCRIPTION
Keep original column references as Arel attributes instead of rendering qualified names and parsing them back into SQL fragments for association projections.

A column's physical source remains distinct from its normalized search expression. Foreign columns likewise distinguish the original association table from the derived search subquery. Existing `full_name` and `to_sql` String interfaces remain available.

Aggregate inputs still skip NULLs rather than coalescing them early. Public behavior coverage checks physical columns shadowed by model attribute aliases and trusted JSON expressions evaluated before aggregation.

Builds on #588. Quoted-value nodes and expression-boundary cleanup will follow separately.
