### PR TITLE
Represent SQL data with quoted Arel nodes

### DIFF
--- a/doc/plans/2026-09-06-arel-remaining-expressions.md
+++ b/doc/plans/2026-09-06-arel-remaining-expressions.md
@@ -22,7 +22,7 @@ data merely to eliminate Ruby interpolation. No new database functions/migration
   expression. Preserve the distinction between a foreign column's original
   association source and its derived search-document alias, non-coalesced
   aggregation, and the existing full_name/to_sql String interfaces.
-- [ ] **Quoted values:** replace hand-quoted data and quote/render/wrap patterns
+- [x] **Quoted values:** replace hand-quoted data and quote/render/wrap patterns
   with quoted-value nodes: separators, empty strings, regex arguments, model
   names, and timestamps. Preserve actual data, escaping, NULL behavior, and the
   shared timestamp. Do not confuse a SQL type token or empty SQL fragment with

--- a/lib/pg_search/configuration/column.rb
+++ b/lib/pg_search/configuration/column.rb
@@ -40,7 +40,7 @@ module PgSearch
       end
 
       def coalesce_to_blank_string(node)
-        Arel::Nodes::NamedFunction.new("coalesce", [node, Arel.sql("''")])
+        Arel::Nodes::NamedFunction.new("coalesce", [node, Arel::Nodes.build_quoted("")])
       end
 
       def source_table = @model.arel_table

--- a/lib/pg_search/features/feature.rb
+++ b/lib/pg_search/features/feature.rb
@@ -25,7 +25,7 @@ module PgSearch
       attr_reader :query, :options, :all_columns, :model, :normalizer
 
       def document
-        space = Arel.sql("' '")
+        space = Arel::Nodes.build_quoted(" ")
         columns.map(&:to_arel).inject do |memo, col|
           Arel::Nodes::InfixOperation.new(
             "||",

--- a/lib/pg_search/features/tsearch.rb
+++ b/lib/pg_search/features/tsearch.rb
@@ -121,7 +121,7 @@ module PgSearch
       end
 
       def tsquery
-        return Arel.sql("''") if query.blank?
+        return Arel::Nodes.build_quoted("") if query.blank?
 
         query_terms = query.split.compact
         query_terms.map { |term| tsquery_for_term(term) }

--- a/lib/pg_search/multisearch/rebuilder.rb
+++ b/lib/pg_search/multisearch/rebuilder.rb
@@ -44,13 +44,13 @@ module PgSearch
 
       def insert_manager
         time = @time_source.call
-        quoted_time = Arel.sql(connection.quote(connection.quoted_date(time)))
+        quoted_time = Arel::Nodes.build_quoted(time)
         src = model.arel_table
         doc = PgSearch::Document.arel_table
 
         sel = Arel::SelectManager.new(src)
         sel.project(
-          Arel.sql(connection.quote(model.base_class.name)).as("searchable_type"),
+          Arel::Nodes.build_quoted(model.base_class.name).as("searchable_type"),
           src[model.primary_key].as("searchable_id"),
           content_expression.as("content"),
           quoted_time.as("created_at"),
@@ -73,12 +73,12 @@ module PgSearch
       end
 
       def content_expression
-        exprs = columns.map { |col| Configuration::Column.new(col, nil, model).to_arel }
-        exprs.reduce do |acc, expr|
+        expressions = columns.map { |column| Configuration::Column.new(column, nil, model).to_arel }
+        expressions.inject do |document, expression|
           Arel::Nodes::InfixOperation.new(
             "||",
-            Arel::Nodes::InfixOperation.new("||", acc, Arel.sql("' '")),
-            expr
+            Arel::Nodes::InfixOperation.new("||", document, Arel::Nodes.build_quoted(" ")),
+            expression
           )
         end
       end

--- a/lib/pg_search/normalizer.rb
+++ b/lib/pg_search/normalizer.rb
@@ -6,7 +6,7 @@ module PgSearch
       @config = config
     end
 
-    DISALLOWED_CHARACTERS = "'[''?\\:]'"
+    DISALLOWED_CHARACTERS = "['?\\:]"
 
     def add_normalization(expression)
       node = to_node(expression)
@@ -16,9 +16,9 @@ module PgSearch
         "regexp_replace",
         [
           Arel::Nodes::NamedFunction.new(PgSearch.unaccent_function, [node]),
-          Arel.sql(DISALLOWED_CHARACTERS),
-          Arel.sql("''"),
-          Arel.sql("'g'")
+          Arel::Nodes.build_quoted(DISALLOWED_CHARACTERS),
+          Arel::Nodes.build_quoted(""),
+          Arel::Nodes.build_quoted("g")
         ]
       )
     end

--- a/spec/lib/pg_search/multisearch/rebuilder_spec.rb
+++ b/spec/lib/pg_search/multisearch/rebuilder_spec.rb
@@ -111,21 +111,22 @@ describe PgSearch::Multisearch::Rebuilder do
             expect(doc.content).to eq("")
           end
 
-          it "stamps both created_at and updated_at from a single time_source call" do
+          it "stamps both timestamps with the precision and offset of one clock call" do
+            time = Time.iso8601("2001-01-01T06:30:00.123456+05:30")
             call_count = 0
             time_source = lambda do
               call_count += 1
-              Time.utc(2001, 1, 1)
+              time
             end
 
-            PgSearch.disable_multisearch { Book.create!(title: "Dune") }
+            book = PgSearch.disable_multisearch { Book.create!(title: "Dune") }
 
             described_class.new(Book, time_source).rebuild
 
             expect(call_count).to eq(1)
-            doc = PgSearch::Document.last
-            expect(doc.created_at).to eq(Time.utc(2001, 1, 1))
-            expect(doc.created_at).to eq(doc.updated_at)
+            document = PgSearch::Document.find_by!(searchable: book)
+            expect(document.created_at).to eq(time)
+            expect(document.updated_at).to eq(time)
           end
         end
 

--- a/spec/lib/pg_search/normalizer_spec.rb
+++ b/spec/lib/pg_search/normalizer_spec.rb
@@ -73,15 +73,15 @@ describe PgSearch::Normalizer do
       table { |t| t.string :title }
     end
 
-    it "strips accents from a real column value when ignoring accents" do
-      Book.create!(title: "caf\u00e9")
+    it "strips accents and disallowed punctuation but preserves backslashes" do
+      Book.create!(title: "café's? déjà: vu\\path")
       config = instance_double(PgSearch::Configuration, ignore: [:accents])
       normalizer = described_class.new(config)
       col = PgSearch::Configuration::Column.new(:title, nil, Book)
       expr = normalizer.add_normalization(col.to_arel)
       sql = "SELECT (#{expr.to_sql}) FROM #{Book.quoted_table_name} LIMIT 1"
       result = ActiveRecord::Base.connection.select_value(sql)
-      expect(result).to eq("cafe")
+      expect(result).to eq("cafes deja vu\\path")
     end
   end
 end


### PR DESCRIPTION
Represent SQL data with Arel quoted-value nodes rather than hand-quoting it or rendering it through the connection and wrapping the result in `Arel.sql`.

This covers separators, empty strings, normalization patterns and flags, model names, and rebuild timestamps. SQL syntax such as the CAST target remains distinct from string data, and documented SQL escape hatches remain supported.

Strengthened existing behavior examples exercise punctuation and backslashes through normalization and preserve one rebuild timestamp across both columns, including fractional seconds and a non-UTC input offset.

Builds on #589. Normalizer attribute handling and remaining internal expression boundaries follow separately.
