### PR TITLE
Preserve Arel expressions across query boundaries

### DIFF
--- a/doc/plans/2026-09-06-arel-remaining-expressions.md
+++ b/doc/plans/2026-09-06-arel-remaining-expressions.md
@@ -27,12 +27,12 @@ data merely to eliminate Ruby interpolation. No new database functions/migration
   names, and timestamps. Preserve actual data, escaping, NULL behavior, and the
   shared timestamp. Do not confuse a SQL type token or empty SQL fragment with
   a string value.
-- [ ] **Expression boundaries:** preserve Arel attributes through normalization
+- [x] **Expression boundaries:** preserve Arel attributes through normalization
   instead of coercing their Ruby inspection into SQL; remove avoidable internal
   render-and-wrap cycles for primary keys and default ranking. Preserve the
   documented custom SQL inputs and legacy String adapters at their boundaries.
   Investigate empty-expression fragments before changing their semantics.
-- [ ] **Final audit:** verify remaining interpolation/raw SQL is intentional
+- [x] **Final audit:** verify remaining interpolation/raw SQL is intentional
   syntax, data serialization, or trusted escape-hatch input; report residue
   rather than hiding it.
 
@@ -45,5 +45,4 @@ additional SQL golden matrices. Run relevant specs and bin/rake independently
 for each layer, including the existing pinned Rails-main environment; require
 one focused independent review per layer and green hosted CI.
 
-Check each item with its owning code. Keep an empty working commit above the
-stack. Until /hi, do not sign; record any new unsigned commits for later signing.
+Check each item with its owning code.

--- a/lib/pg_search/configuration/association.rb
+++ b/lib/pg_search/configuration/association.rb
@@ -22,12 +22,15 @@ module PgSearch
       def arel_table = @model.reflect_on_association(@name).klass.arel_table
 
       def join(primary_key)
-        subquery = relation(primary_key).arel.as(subselect_alias)
-        on_condition = Arel::Nodes::On.new(
-          subquery[:id].eq(Arel.sql(primary_key))
-        )
-        node = Arel::Nodes::OuterJoin.new(subquery, on_condition)
+        node = to_arel(primary_key)
         @model.connection.unprepared_statement { @model.connection.to_sql(node) }
+      end
+
+      def to_arel(primary_key)
+        primary_key = Arel.sql(primary_key) if primary_key.is_a?(String)
+        subquery = relation(primary_key).arel.as(subselect_alias)
+        on_condition = Arel::Nodes::On.new(subquery[:id].eq(primary_key))
+        Arel::Nodes::OuterJoin.new(subquery, on_condition)
       end
 
       def subselect_alias
@@ -38,7 +41,7 @@ module PgSearch
 
       def relation(primary_key)
         result = @model.unscoped.joins(@name).select(
-          Arel.sql(primary_key).as("id"),
+          primary_key.as("id"),
           *selects
         )
         result = result.group(primary_key) unless singular_association?

--- a/lib/pg_search/normalizer.rb
+++ b/lib/pg_search/normalizer.rb
@@ -29,10 +29,12 @@ module PgSearch
 
     def to_node(expression)
       case expression
-      when Arel::Nodes::Node
+      when Arel::Nodes::Node, Arel::Attributes::Attribute
         expression
+      when String
+        Arel.sql(expression)
       else
-        Arel.sql(expression.to_s)
+        raise TypeError
       end
     end
   end

--- a/lib/pg_search/scope_options.rb
+++ b/lib/pg_search/scope_options.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "active_support/core_ext/module/delegation"
-
 module PgSearch
   class ScopeOptions
     attr_reader :config, :feature_options, :model
@@ -81,13 +79,11 @@ module PgSearch
 
     private
 
-    delegate :connection, to: :model
-
     def subquery
       model
         .unscoped
         .select(model.arel_table[model.primary_key].as("pg_search_id"))
-        .select(Arel.sql(rank).as("rank"))
+        .select(rank.as("rank"))
         .joins(subquery_join)
         .where(conditions)
         .limit(nil)
@@ -112,19 +108,11 @@ module PgSearch
     end
 
     def primary_key
-      attribute = Arel::Attributes::Attribute.new(
-        model.arel_table,
-        model.primary_key
-      )
-      connection.visitor.compile(attribute)
+      Arel::Attributes::Attribute.new(model.arel_table, model.primary_key)
     end
 
     def subquery_join
-      if config.associations.any?
-        config.associations.map do |association|
-          association.join(primary_key)
-        end.join(" ")
-      end
+      config.associations.map { |association| association.to_arel(primary_key) }
     end
 
     FEATURE_CLASSES = { # standard:disable Lint/UselessConstantScoping
@@ -151,9 +139,11 @@ module PgSearch
     end
 
     def rank
-      (config.ranking_sql || ":tsearch").gsub(/:(\w*)/) do
+      return feature_for(:tsearch).rank unless config.ranking_sql
+
+      Arel.sql(config.ranking_sql.gsub(/:(\w*)/) do
         feature_for(Regexp.last_match(1)).rank.to_sql
-      end
+      end)
     end
 
     def rank_join(rank_subquery)

--- a/spec/integration/associations_spec.rb
+++ b/spec/integration/associations_spec.rb
@@ -175,7 +175,7 @@ describe "a pg_search_scope" do
         end
       end
 
-      it "applies the association condition and handles single-quoted values without bind placeholders" do
+      it "preserves scoped values through searches and the String join adapter" do
         shelf_with_obrien = Shelf.create!(title: "Main Shelf")
         shelf_without_obrien = Shelf.create!(title: "Other Shelf")
 
@@ -193,6 +193,19 @@ describe "a pg_search_scope" do
         results = Shelf.with_obrien_books("Third Policeman")
         expect(results).to include(shelf_with_obrien)
         expect(results).not_to include(shelf_without_obrien)
+
+        association = PgSearch::Configuration::Association.new(
+          Shelf, :obrien_books, :title
+        )
+        primary_key = Shelf.connection.visitor.compile(Shelf.arel_table[:id])
+        join = association.join(primary_key)
+        column = Shelf.arel_table.alias(association.subselect_alias)[
+          association.columns.first.alias
+        ]
+
+        expect(join).to be_a(String)
+        expect(Shelf.joins(join).where(column.not_eq(nil)))
+          .to contain_exactly(shelf_with_obrien)
       end
     end
 

--- a/spec/lib/pg_search/configuration/association_spec.rb
+++ b/spec/lib/pg_search/configuration/association_spec.rb
@@ -130,13 +130,16 @@ describe PgSearch::Configuration::Association do
       it "returns the correct SQL join" do
         expect(association.join("model_id")).to eq(expected_sql)
       end
+    end
 
+    describe "#to_arel" do
       let(:projected_column) do
-        Arel.sql("#{association.subselect_alias}.#{association.columns.first.alias}")
+        Site.arel_table.alias(association.subselect_alias)[
+          association.columns.first.alias
+        ].as("document")
       end
       let(:joined_sites) do
-        primary_key = Site.connection.visitor.compile(Site.arel_table[:id])
-        Site.joins(association.join(primary_key))
+        Site.joins(association.to_arel(Site.arel_table[:id]))
       end
 
       it "ignores NULL inputs without padding the aggregate" do

--- a/spec/lib/pg_search/normalizer_spec.rb
+++ b/spec/lib/pg_search/normalizer_spec.rb
@@ -57,6 +57,15 @@ describe PgSearch::Normalizer do
       end
     end
 
+    it "rejects unsupported inputs instead of turning them into SQL" do
+      config = instance_double(PgSearch::Configuration, ignore: [])
+      normalizer = described_class.new(config)
+
+      [nil, Object.new, 123].each do |input|
+        expect { normalizer.add_normalization(input) }.to raise_error(TypeError)
+      end
+    end
+
     context "when config[:ignore] does not include :accents" do
       it "passes the expression through as an Arel-compatible object" do
         config = instance_double(PgSearch::Configuration, "config", ignore: [])
@@ -77,11 +86,29 @@ describe PgSearch::Normalizer do
       Book.create!(title: "café's? déjà: vu\\path")
       config = instance_double(PgSearch::Configuration, ignore: [:accents])
       normalizer = described_class.new(config)
-      col = PgSearch::Configuration::Column.new(:title, nil, Book)
-      expr = normalizer.add_normalization(col.to_arel)
-      sql = "SELECT (#{expr.to_sql}) FROM #{Book.quoted_table_name} LIMIT 1"
-      result = ActiveRecord::Base.connection.select_value(sql)
-      expect(result).to eq("cafes deja vu\\path")
+      expression = normalizer.add_normalization(Book.arel_table[:title])
+
+      expect(Book.pick(expression)).to eq("cafes deja vu\\path")
+    end
+
+    it "preserves attributes when accents are not ignored" do
+      book = Book.create!(title: "café's? déjà: vu\\path")
+      config = instance_double(PgSearch::Configuration, ignore: [])
+      normalizer = described_class.new(config)
+      expression = normalizer.add_normalization(Book.arel_table[:title])
+
+      expect(Book.pick(expression)).to eq(book.title)
+    end
+
+    it "preserves quoted data rather than interpreting it as SQL" do
+      Book.create!
+      value = Arel::Nodes.build_quoted("café's? déjà: vu\\path")
+      config = instance_double(PgSearch::Configuration, ignore: [])
+      normalizer = described_class.new(config)
+
+      expect(normalizer.add_normalization(value)).to equal(value)
+      expect(Book.pick(normalizer.add_normalization(value)))
+        .to eq("café's? déjà: vu\\path")
     end
   end
 end


### PR DESCRIPTION
Keep expressions as Arel nodes across normalization, ranking, and association joins instead of rendering and wrapping them again.

Normalizer previously recognized node subclasses but not Arel attributes, which are separate objects. Passing an attribute turned its Ruby inspection into SQL. Preserve attributes alongside nodes, retain trusted String SQL input, and reject unsupported objects rather than silently stringifying them.

The default rank now remains an expression. Association exposes an Arel join consumed directly by scope construction, allowing scoped bind values to travel through Active Record's collector. The existing String join adapter still renders through the unprepared path, and custom ranking/ordering SQL remains supported.

Public examples exercise attribute normalization, node-based joins, NULL aggregation, scoped conditions containing quotes, and the legacy String adapter. The empty-source tsearch fragment remains unchanged: removing it changes existing failure behavior and would require a separate validation decision.

Continues above #590 without changing the earlier review heads.
