### PR TITLE
Remove orphaned Arel rendering adapters

### DIFF
--- a/lib/pg_search/configuration/association.rb
+++ b/lib/pg_search/configuration/association.rb
@@ -21,11 +21,6 @@ module PgSearch
 
       def arel_table = @model.reflect_on_association(@name).klass.arel_table
 
-      def join(primary_key)
-        node = to_arel(primary_key)
-        @model.connection.unprepared_statement { @model.connection.to_sql(node) }
-      end
-
       def to_arel(primary_key)
         primary_key = Arel.sql(primary_key) if primary_key.is_a?(String)
         subquery = relation(primary_key).arel.as(subselect_alias)

--- a/lib/pg_search/configuration/column.rb
+++ b/lib/pg_search/configuration/column.rb
@@ -12,10 +12,7 @@ module PgSearch
         @column_name = column_name
         @weight = weight
         @model = model
-        @connection = model.connection
       end
-
-      def full_name = @connection.visitor.compile(source_attribute)
 
       def source_attribute
         return @column_name if @column_name.is_a?(Arel::Nodes::SqlLiteral)
@@ -24,8 +21,6 @@ module PgSearch
       end
 
       def to_arel = coalesce_to_blank_string(cast_to_text(attribute))
-
-      def to_sql = @connection.visitor.compile(to_arel)
 
       private
 

--- a/lib/pg_search/features/feature.rb
+++ b/lib/pg_search/features/feature.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-require "active_support/core_ext/module/delegation"
 require "active_support/core_ext/hash/keys"
 
 module PgSearch
@@ -9,8 +8,6 @@ module PgSearch
       def self.valid_options
         %i[only sort_only]
       end
-
-      delegate :connection, :quoted_table_name, to: :@model
 
       def initialize(query, options, all_columns, model, normalizer)
         @query = query

--- a/lib/pg_search/scope_options.rb
+++ b/lib/pg_search/scope_options.rb
@@ -41,10 +41,6 @@ module PgSearch
         scope = scope.select(arel_table[Arel.star]) if scope.select_values.empty?
         scope.select(tsearch.highlight.as("pg_search_highlight"))
       end
-
-      def highlight
-        tsearch.highlight.to_sql
-      end
     end
 
     module WithPgSearchRank

--- a/spec/integration/associations_spec.rb
+++ b/spec/integration/associations_spec.rb
@@ -175,7 +175,7 @@ describe "a pg_search_scope" do
         end
       end
 
-      it "preserves scoped values through searches and the String join adapter" do
+      it "preserves scoped values through searches" do
         shelf_with_obrien = Shelf.create!(title: "Main Shelf")
         shelf_without_obrien = Shelf.create!(title: "Other Shelf")
 
@@ -193,19 +193,6 @@ describe "a pg_search_scope" do
         results = Shelf.with_obrien_books("Third Policeman")
         expect(results).to include(shelf_with_obrien)
         expect(results).not_to include(shelf_without_obrien)
-
-        association = PgSearch::Configuration::Association.new(
-          Shelf, :obrien_books, :title
-        )
-        primary_key = Shelf.connection.visitor.compile(Shelf.arel_table[:id])
-        join = association.join(primary_key)
-        column = Shelf.arel_table.alias(association.subselect_alias)[
-          association.columns.first.alias
-        ]
-
-        expect(join).to be_a(String)
-        expect(Shelf.joins(join).where(column.not_eq(nil)))
-          .to contain_exactly(shelf_with_obrien)
       end
     end
 

--- a/spec/lib/pg_search/configuration/association_spec.rb
+++ b/spec/lib/pg_search/configuration/association_spec.rb
@@ -50,27 +50,6 @@ describe PgSearch::Configuration::Association do
         expect(association.table_name).to eq Avatar.table_name
       end
     end
-
-    describe "#join" do
-      let(:expected_sql) do
-        <<~SQL.squish
-          LEFT OUTER JOIN
-            (SELECT model_id AS id,
-                    #{column_select} AS #{association.columns.first.alias}
-            FROM "#{User.table_name}"
-            INNER JOIN "#{association.table_name}"
-            ON "#{association.table_name}"."user_id" = "#{User.table_name}"."id") #{association.subselect_alias}
-          ON #{association.subselect_alias}."id" = model_id
-        SQL
-      end
-      let(:column_select) do
-        "cast(\"#{association.table_name}\".\"url\" AS text)"
-      end
-
-      it "returns the correct SQL join" do
-        expect(association.join("model_id")).to eq(expected_sql)
-      end
-    end
   end
 
   context "with belongs_to" do
@@ -81,27 +60,6 @@ describe PgSearch::Configuration::Association do
         expect(association.table_name).to eq Site.table_name
       end
     end
-
-    describe "#join" do
-      let(:expected_sql) do
-        <<~SQL.squish
-          LEFT OUTER JOIN
-            (SELECT model_id AS id,
-                    #{column_select} AS #{association.columns.first.alias}
-            FROM "#{User.table_name}"
-            INNER JOIN "#{association.table_name}"
-            ON "#{association.table_name}"."id" = "#{User.table_name}"."site_id") #{association.subselect_alias}
-          ON #{association.subselect_alias}."id" = model_id
-        SQL
-      end
-      let(:column_select) do
-        "cast(\"#{association.table_name}\".\"title\" AS text)"
-      end
-
-      it "returns the correct SQL join" do
-        expect(association.join("model_id")).to eq(expected_sql)
-      end
-    end
   end
 
   context "with has_many" do
@@ -110,25 +68,6 @@ describe PgSearch::Configuration::Association do
     describe "#table_name" do
       it "returns the table name for the associated model" do
         expect(association.table_name).to eq User.table_name
-      end
-    end
-
-    describe "#join" do
-      let(:expected_sql) do
-        <<~SQL.squish
-          LEFT OUTER JOIN
-            (SELECT model_id AS id,
-                    string_agg(cast("#{association.table_name}"."name" AS text), ' ') AS #{association.columns.first.alias}
-            FROM "#{Site.table_name}"
-            INNER JOIN "#{association.table_name}"
-            ON "#{association.table_name}"."site_id" = "#{Site.table_name}"."id"
-            GROUP BY model_id) #{association.subselect_alias}
-          ON #{association.subselect_alias}."id" = model_id
-        SQL
-      end
-
-      it "returns the correct SQL join" do
-        expect(association.join("model_id")).to eq(expected_sql)
       end
     end
 

--- a/spec/lib/pg_search/configuration/column_spec.rb
+++ b/spec/lib/pg_search/configuration/column_spec.rb
@@ -3,25 +3,6 @@
 require "spec_helper"
 
 describe PgSearch::Configuration::Column do
-  describe "#full_name" do
-    with_model :Model do
-      table do |t|
-        t.string :name
-        t.json :object
-      end
-    end
-
-    it "returns the fully-qualified table and column name" do
-      column = described_class.new("name", nil, Model)
-      expect(column.full_name).to eq(%(#{Model.quoted_table_name}."name"))
-    end
-
-    it "returns nested json attributes" do
-      column = described_class.new(Arel.sql("object->>'name'"), nil, Model)
-      expect(column.full_name).to eq(%(object->>'name'))
-    end
-  end
-
   describe "#to_arel" do
     with_model :Model do
       table do |t|
@@ -109,28 +90,12 @@ describe PgSearch::Configuration::Column do
       end
     end
 
-    it "keeps full_name physical while normalizing the model attribute" do
+    it "normalizes the aliased model attribute" do
       Book.create!(title: "physical", name: "alias")
       Book.alias_attribute :title, :name
       column = described_class.new(:title, nil, Book)
 
-      expect(Book.pluck(Arel.sql(column.full_name))).to eq ["physical"]
       expect(Book.pluck(column.to_arel)).to eq ["alias"]
-    end
-  end
-
-  describe "#to_sql" do
-    with_model :Model do
-      table do |t|
-        t.string :name
-      end
-    end
-
-    it "uses the model connection's visitor as a String adapter" do
-      column = described_class.new("name", nil, Model)
-
-      expect(column.to_sql).to be_a(String)
-      expect(column.to_sql).to eq(Model.connection.visitor.compile(column.to_arel))
     end
   end
 end

--- a/spec/lib/pg_search/configuration/foreign_column_spec.rb
+++ b/spec/lib/pg_search/configuration/foreign_column_spec.rb
@@ -37,19 +37,10 @@ describe PgSearch::Configuration::ForeignColumn do
     end
   end
 
-  describe "#full_name" do
-    it "returns the fully-qualified associated table and column name" do
-      expect(foreign_column.full_name).to eq(
-        %(#{AssociatedModel.quoted_table_name}."title")
-      )
-    end
-  end
-
   describe "#to_arel" do
     def selected_value(model)
-      primary_key = Model.connection.visitor.compile(Model.arel_table[:id])
       relation = Model
-        .joins(association.join(primary_key))
+        .joins(association.to_arel(Model.arel_table[:id]))
         .where(Model.arel_table[:id].eq(model.id))
         .select(foreign_column.to_arel.as("value"))
       sql = Model.connection.visitor.compile(relation.arel.ast)
@@ -75,15 +66,6 @@ describe PgSearch::Configuration::ForeignColumn do
       model = Model.create!(name: "example", associated_model: nil)
 
       expect(selected_value(model)).to eq("")
-    end
-  end
-
-  describe "#to_sql" do
-    it "uses the model connection's visitor as a String adapter" do
-      expect(foreign_column.to_sql).to be_a(String)
-      expect(foreign_column.to_sql).to eq(
-        Model.connection.visitor.compile(foreign_column.to_arel)
-      )
     end
   end
 end


### PR DESCRIPTION
Remove undocumented Arel implementation methods that no production path calls.

The refactor now carries expressions through normalizer, search features, association joins, and rebuild construction. The old String rendering adapters and forwarding helpers remained only because their direct specs invoked them. Remove those test-only interfaces and keep coverage at the public search and rebuild boundaries.

This preserves database coverage for highlighting, aliases, NULL aggregation, scoped association values, and rebuilt documents.
