### PR TITLE
Document Arel expression boundaries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 * Drop support for Active Record 7.2
+* Compose search queries with Arel expressions while preserving custom SQL options
 
 ## 2.3.8
 

--- a/lib/pg_search/configuration/association.rb
+++ b/lib/pg_search/configuration/association.rb
@@ -21,6 +21,11 @@ module PgSearch
 
       def arel_table = @model.reflect_on_association(@name).klass.arel_table
 
+      # Builds an outer join retaining association-scope binds.
+      #
+      # @param primary_key an Arel expression or trusted SQL String identifying
+      #   the model's primary-key column, not a record's key value
+      # @return [Arel::Nodes::OuterJoin] a composable join to the search subquery
       def to_arel(primary_key)
         primary_key = Arel.sql(primary_key) if primary_key.is_a?(String)
         subquery = relation(primary_key).arel.as(subselect_alias)

--- a/lib/pg_search/configuration/column.rb
+++ b/lib/pg_search/configuration/column.rb
@@ -14,12 +14,16 @@ module PgSearch
         @model = model
       end
 
+      # Physical source-column attribute, or the supplied trusted SQL literal.
+      # Foreign columns refer to the association table, not the search alias.
       def source_attribute
         return @column_name if @column_name.is_a?(Arel::Nodes::SqlLiteral)
 
         Arel::Attributes::Attribute.new(source_table, @name)
       end
 
+      # Composable search expression cast to text, with NULL mapped to "".
+      # Foreign columns use their derived search alias rather than the source.
       def to_arel = coalesce_to_blank_string(cast_to_text(attribute))
 
       private

--- a/lib/pg_search/features.rb
+++ b/lib/pg_search/features.rb
@@ -7,6 +7,8 @@ require "pg_search/features/trigram"
 require "pg_search/features/tsearch"
 
 module PgSearch
+  # Search features provide conditions and rank as composable Arel expressions,
+  # not SQL Strings. TSearch also provides a highlight expression for selection.
   module Features
   end
 end

--- a/lib/pg_search/multisearch/rebuilder.rb
+++ b/lib/pg_search/multisearch/rebuilder.rb
@@ -3,6 +3,11 @@
 module PgSearch
   module Multisearch
     class Rebuilder
+      # @param model [Class] an Active Record model configured for multisearch
+      # @param time_source [#call] clock returning a timestamp for bulk inserts;
+      #   defaults to Time.method(:now), called once per bulk rebuild so created_at
+      #   and updated_at share a timestamp
+      # @raise [ModelNotMultisearchable] if model is not configured for multisearch
       def initialize(model, time_source = Time.method(:now))
         raise ModelNotMultisearchable, model unless model.respond_to?(:pg_search_multisearchable_options)
 
@@ -10,6 +15,10 @@ module PgSearch
         @time_source = time_source
       end
 
+      # Populates search documents without first clearing existing documents.
+      # Uses the model's rebuild_pg_search_documents override when available;
+      # otherwise updates records individually for conditions, dynamic content,
+      # or additional attributes, and bulk-inserts for plain column content.
       def rebuild
         if model.respond_to?(:rebuild_pg_search_documents)
           model.rebuild_pg_search_documents

--- a/lib/pg_search/normalizer.rb
+++ b/lib/pg_search/normalizer.rb
@@ -2,12 +2,21 @@
 
 module PgSearch
   class Normalizer
+    # @param config [PgSearch::Configuration] search configuration whose ignore
+    #   list controls accent normalization
     def initialize(config)
       @config = config
     end
 
     DISALLOWED_CHARACTERS = "['?\\:]"
 
+    # Applies configured accent normalization, preserving the input expression
+    # without an unaccent wrapper when accents are not ignored.
+    #
+    # @param expression an Arel node, attribute, or trusted SQL String;
+    #   a String is an SQL expression, not a value to quote
+    # @return a composable Arel expression
+    # @raise [TypeError] if expression is not an Arel node, attribute, or String
     def add_normalization(expression)
       node = to_node(expression)
       return node unless config.ignore.include?(:accents)


### PR DESCRIPTION
Document the public Arel expression boundaries introduced by the recent refactor.

The comments distinguish source attributes from normalized search expressions, explain how normalization accepts expressions and trusted SQL, and describe the multisearch rebuild dispatch paths. The Unreleased note records the composable Arel interfaces.

Follows #593, which removed the unused rendering adapters rather than documenting them as supported APIs.
