### PR TITLE
Use native RDoc markup

### DIFF
--- a/lib/pg_search/configuration/association.rb
+++ b/lib/pg_search/configuration/association.rb
@@ -23,9 +23,12 @@ module PgSearch
 
       # Builds an outer join retaining association-scope binds.
       #
-      # @param primary_key an Arel expression or trusted SQL String identifying
-      #   the model's primary-key column, not a record's key value
-      # @return [Arel::Nodes::OuterJoin] a composable join to the search subquery
+      # Arguments
+      #
+      # +primary_key+:: An Arel expression or trusted SQL String identifying the
+      #                 model's primary-key column, not a record's key value.
+      #
+      # Returns a composable outer join to the search subquery.
       def to_arel(primary_key)
         primary_key = Arel.sql(primary_key) if primary_key.is_a?(String)
         subquery = relation(primary_key).arel.as(subselect_alias)

--- a/lib/pg_search/multisearch/rebuilder.rb
+++ b/lib/pg_search/multisearch/rebuilder.rb
@@ -3,11 +3,16 @@
 module PgSearch
   module Multisearch
     class Rebuilder
-      # @param model [Class] an Active Record model configured for multisearch
-      # @param time_source [#call] clock returning a timestamp for bulk inserts;
-      #   defaults to Time.method(:now), called once per bulk rebuild so created_at
-      #   and updated_at share a timestamp
-      # @raise [ModelNotMultisearchable] if model is not configured for multisearch
+      # Arguments
+      #
+      # +model+:: Active Record model configured for multisearch.
+      # +time_source+:: Clock returning a timestamp for bulk inserts. Defaults to
+      #                 +Time.method(:now)+ and is called once per bulk rebuild so
+      #                 +created_at+ and +updated_at+ share a timestamp.
+      #
+      # Raises
+      #
+      # ModelNotMultisearchable:: If +model+ is not configured for multisearch.
       def initialize(model, time_source = Time.method(:now))
         raise ModelNotMultisearchable, model unless model.respond_to?(:pg_search_multisearchable_options)
 

--- a/lib/pg_search/normalizer.rb
+++ b/lib/pg_search/normalizer.rb
@@ -2,8 +2,10 @@
 
 module PgSearch
   class Normalizer
-    # @param config [PgSearch::Configuration] search configuration whose ignore
-    #   list controls accent normalization
+    # Arguments
+    #
+    # +config+:: Search configuration whose ignore list controls accent
+    #            normalization.
     def initialize(config)
       @config = config
     end
@@ -13,10 +15,16 @@ module PgSearch
     # Applies configured accent normalization, preserving the input expression
     # without an unaccent wrapper when accents are not ignored.
     #
-    # @param expression an Arel node, attribute, or trusted SQL String;
-    #   a String is an SQL expression, not a value to quote
-    # @return a composable Arel expression
-    # @raise [TypeError] if expression is not an Arel node, attribute, or String
+    # Arguments
+    #
+    # +expression+:: An Arel node, attribute, or trusted SQL String. A String is
+    #                an SQL expression, not a value to quote.
+    #
+    # Returns a composable Arel expression.
+    #
+    # Raises
+    #
+    # TypeError:: If +expression+ is not an Arel node, attribute, or String.
     def add_normalization(expression)
       node = to_node(expression)
       return node unless config.ignore.include?(:accents)


### PR DESCRIPTION
Correct the Arel-boundary documentation added for 2.4.0 to use native RDoc markup.

RDoc rendered the previous YARD-style `@param`, `@return`, and `@raise` lines as literal text. This replaces them with RDoc definition lists and section headings while retaining the same contracts for association joins, normalization, and multisearch rebuilding.
