### PR TITLE
Prepare 2.4.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,9 @@
 # pg_search changelog
 
-## Unreleased
+## 2.4.0 - 2026-09-07
 
 * Drop support for Active Record 7.2
-* Compose search queries with Arel expressions while preserving custom SQL options
+* Replace internal SQL-string manipulation with composable Arel operations while preserving all existing use cases
 
 ## 2.3.8 - 2026-08-10
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 * Drop support for Active Record 7.2
 * Compose search queries with Arel expressions while preserving custom SQL options
 
-## 2.3.8
+## 2.3.8 - 2026-08-10
 
 * Drop support for Ruby 3.0, 3.1, and 3.2
 * Drop support for Active Record 6.1, 7.0, and 7.1
@@ -17,7 +17,7 @@
 * Quote custom primary key and inheritance column identifiers in multisearch rebuild SQL
 * Improve documentation (Olli)
 
-## 2.3.7
+## 2.3.7 - 2024-08-11
 
 * Drop support for Ruby 2.6 and 2.7
 * Drop support for Active Record 6.0 and earlier
@@ -28,7 +28,7 @@
 * add support for Arel::Nodes::SqlLiteral columns (Kyle Fazzari)
 * Improve documentation (Prima Aulia Gusta, Ross Baird, Andy Atkinson)
 
-## 2.3.6
+## 2.3.6 - 2022-01-07
 
 * Drop support for Ruby 2.5
 * Support Ruby 3.1
@@ -37,186 +37,186 @@
 * Optionally disable transaction when rebuilding documents (Travis Hunter)
 * Preserve columns when chaining ::with_pg_search_highlight (jcsanti)
 
-## 2.3.5
+## 2.3.5 - 2020-11-16
 
 * Add table of contents to README (Barry Woolgar)
 * Add support for Active Record 6.1
 
-## 2.3.4
+## 2.3.4 - 2020-10-10
 
 * Fix issue when setting various options directly on the `PgSearch` module while
   running with a threaded web server, such as Puma. (Anton Rieder)
 
-## 2.3.3
+## 2.3.3 - 2020-09-20
 
 * Drop support for Ruby < 2.5.
 * Use keyword argument for `clean_up` setting in `PgSearch::Multisearch.rebuild`.
 
-## 2.3.2
+## 2.3.2 - 2020-01-13
 
 * Autoload `PgSearch::Document` to prevent it from being loaded in projects that are not using multi-search.
 * Rebuilder should use `update_pg_search_document` if `additional_attributes` is set. (David Ramalho)
 
-## 2.3.1
+## 2.3.1 - 2019-12-22
 
 * Drop support for Active Record < 5.2.
 * Do not load railtie unless Rails::Railtie is defined, to avoid problem when loading alongside Action Mailer. (Adam Schwartz)
 
-## 2.3.0
+## 2.3.0 - 2019-07-13
 
 * Extract `PgSearch::Model` module.
 * Deprecate `include PgSearch`. Use `include PgSearch::Model` instead.
 
-## 2.2.0
+## 2.2.0 - 2019-05-26
 
 * Add `word_similarity` option to trigram search. (Severin Räz)
 
-## 2.1.7
+## 2.1.7 - 2019-04-20
 
 * Restore link to GitHub repository to original location.
 
-## 2.1.6
+## 2.1.6 - 2019-04-18
 
 * Update link to GitHub repository to new location.
 
-## 2.1.5
+## 2.1.5 - 2019-04-08
 
 * Drop support for Ruby < 2.4.
 
-## 2.1.4
+## 2.1.4 - 2019-01-26
 
 * Drop support for Ruby < 2.3.
 * Use `update` instead of deprecated `update_attributes`.
 * Remove explicit Arel dependency to better support Active Record 6 beta.
 
-## 2.1.3
+## 2.1.3 - 2018-12-09
 
 * Drop support for Ruby < 2.2
 * Disallow left/right single quotation marks in tsquery. (Fabian Schwahn) (#382)
 * Do not attempt to save an already-destroyed `PgSearch::Document`. (Oleg Dashevskii, Vokhmin Aleksei V) (#353)
 * Quote column name when rebuilding. (Jed Levin) (#379)
 
-## 2.1.2
+## 2.1.2 - 2017-12-25
 
 * Silence warnings in Rails 5.2.0.beta2. (Kevin Deisz)
 
-## 2.1.1
+## 2.1.1 - 2017-09-20
 
 * Support snake_case `ts_headline` options again. (with deprecation warning)
 
-## 2.1.0
+## 2.1.0 - 2017-07-29
 
 * Allow `ts_headline` options to be passed to `:highlight`. (Ian Heisters)
 * Wait to load `PgSearch::Document` until after Active Record has loaded. (Logan Leger)
 * Add Rails version to generated migrations. (Erik Eide)
 
-## 2.0.1
+## 2.0.1 - 2016-12-20
 
 * Remove require for generator that no longer exists. (Joshua Bartlett)
 
-## 2.0.0
+## 2.0.0 - 2016-12-19
 
 * Drop support for PostgreSQL < 9.2.
 * Drop support for Active Record < 4.2.
 * Drop support for Ruby < 2.1.
 * Improve performance of has_one and belongs_to associations. (Peter Postma)
 
-## 1.0.6
+## 1.0.6 - 2016-05-22
 
 * Add support for highlighting the matching portion of a search result. (Jose Galisteo)
 * Add `:update_if` option to control when PgSearch::Document gets updated. (Adam Becker)
 * Add `:additional_attributes` option for adding additional attributes to PgSearch::Document
 
-## 1.0.5
+## 1.0.5 - 2015-08-30
 
 * Clean up rank table aliasing. (Adam Milligan)
 * Fix issue when using `#with_pg_search_rank` across a join. (Reid Lynch)
 
-## 1.0.4
+## 1.0.4 - 2015-06-14
 
 * Assert valid options for features. (Janko Marohnić)
 * Enable chaining of pg_search scopes. (Nicolas Buduroi)
 
-## 1.0.3
+## 1.0.3 - 2015-05-11
 
 * Support STI models using a custom inheritance column. (Nick Doiron)
 
-## 1.0.2
+## 1.0.2 - 2015-05-04
 
 * Don’t use SQL to rebuild search documents when models are multisearchable against dynamic methods and not just columns. Iterate over each record with `find_each` instead.
 
-## 1.0.1
+## 1.0.1 - 2015-05-02
 
 * Call `.unscoped` on relation used to build subquery, to eliminate unnecessary JOINs. (Markus Doits)
 
-## 1.0.0
+## 1.0.0 - 2015-04-19
 
 * Support more `ActiveRecord::Relation` methods, such as `#pluck` and `#select` by moving search-related operations to subquery.
 * Generate index by default in migration for `pg_search_documents` table.
 * Start officially using [Semantic Versioning 2.0.0](http://semver.org/spec/v2.0.0.html).
 
-## 0.7.9
+## 0.7.9 - 2015-02-04
 
 * Improve support for single table inheritance (STI) models. (Ewan McDougall)
 
-## 0.7.8
+## 0.7.8 - 2014-09-06
 
 * Stop inadvertently including binstubs for guard and rspec.
 
-## 0.7.7
+## 0.7.7 - 2014-09-05
 
 * Fix future compatibility with Active Record 4.2.
 
-## 0.7.6
+## 0.7.6 - 2014-07-16
 
 * Fix migration generator in Rails 3. (Andrew Marshall and Nora Lin)
 * Add `:only` option for limiting search fields per feature. (Jonathan Greenberg)
 
-## 0.7.5
+## 0.7.5 - 2014-07-15
 
 * Add option to make feature available only for sorting. (Brent Wheeldon)
 
-## 0.7.4
+## 0.7.4 - 2014-05-19
 
 * Fix which STI class name is used for searchable_type for PgSearch::Document. (Ewan McDougall)
 * Add support for non-standard primary keys. (Matt Beedle)
 
-## 0.7.3
+## 0.7.3 - 2014-01-26
 
 * Allow simultaneously searching using `:associated_against` and `:tsvector_column` (Adam Becker)
 
-## 0.7.2
+## 0.7.2 - 2013-11-20
 
 * Add :threshold option for configuring how permissive trigram searches are.
 
-## 0.7.1
+## 0.7.1 - 2013-11-20
 
 * Fix issue with {:using => :trigram, :ignoring => :accents} that generated
   bad SQL. (Steven Harman)
 
-## 0.7.0
+## 0.7.0 - 2013-07-05
 
 * Start requiring Ruby 1.9.2 or later.
 
-## 0.6.4
+## 0.6.4 - 2013-05-26
 
 * Fix issue with using more than two features in the same scope.
 
-## 0.6.3
+## 0.6.3 - 2013-05-12
 
 * Fix issues and deprecations for Active Record 4.0.0.rc1.
 
-## 0.6.2
+## 0.6.2 - 2013-04-20
 
 * Add workaround for issue with how ActiveRecord relations handle Arel OR
   nodes.
 
-## 0.6.1
+## 0.6.1 - 2013-04-08
 
 * Fix issue with Arel::InfixOperation that prevented #count from working,
   breaking pagination.
 
-## 0.6.0
+## 0.6.0 - 2013-04-02
 
 * Drop support for Active Record 3.0.
 * Address warnings in Ruby 2.0.
@@ -226,49 +226,49 @@
 * Support named schemas in pg_search:multisearch:rebuild. (Victor Olteanu)
 
 
-## 0.5.7
+## 0.5.7 - 2012-10-07
 
 * Fix issue with eager loading now that the Scope class has been removed.
   (Piotr Murach)
 
 
-## 0.5.6
+## 0.5.6 - 2012-09-29
 
 * PgSearch#multisearchable accepts :if and :unless for conditional inclusion
   in search documents table. (Francois Harbec)
 * Stop using array_to_string() in SQL since it is not indexable.
 
 
-## 0.5.5
+## 0.5.5 - 2012-09-16
 
 * Fix bug with single table inheritance.
 * Allow option for specifying an alternate function for unaccent().
 
 
-## 0.5.4
+## 0.5.4 - 2012-09-07
 
 * Fix bug in associated_against join clause when search scope is chained
   after other scopes.
 * Fix autoloading of PgSearch::VERSION constant.
 
 
-## 0.5.3
+## 0.5.3 - 2012-09-06
 
 * Prevent multiple attempts to create pg_search_document within a single
   transaction. (JT Archie & Trace Wax)
 
 
-## 0.5.2
+## 0.5.2 - 2012-09-06
 
 * Don't save twice if pg_search_document is missing on update.
 
 
-## 0.5.1
+## 0.5.1 - 2012-08-01
 
 * Add ability to override multisearch rebuild SQL.
 
 
-## 0.5
+## 0.5 - 2012-05-13
 
 * Convert migration rake tasks into generators.
 * Use rake task arguments for multisearch rebuild instead of environment
@@ -276,7 +276,7 @@
 * Always cast columns to text.
 
 
-## 0.4.2
+## 0.4.2 - 2012-05-09
 
 * Fill in timestamps correctly when rebuilding multisearch documents.
   (Barton McGuire)
@@ -286,7 +286,7 @@
 * Fix issue with :associated_against and non-text columns.
 
 
-## 0.4.1
+## 0.4.1 - 2012-02-13
 
 * Fix Active Record 3.2 deprecation warnings. (Steven Harman)
 
@@ -294,18 +294,18 @@
   defined.
 
 
-## 0.4
+## 0.4 - 2011-12-15
 
 * Add ability to search again tsvector columns. (Kris Hicks)
 
 
-## 0.3.4
+## 0.3.4 - 2011-11-25
 
 * Fix issue with {:using => {:tsearch => {:prefix => true}}} and hyphens.
 * Get tests running against PostgreSQL 9.1 by using CREATE EXTENSION
 
 
-## 0.3.3
+## 0.3.3 - 2011-10-22
 
 * Backport array_agg() aggregate function to PostgreSQL 8.3 and earlier.
   This fixes :associated_against searches.
@@ -315,18 +315,18 @@
   earlier.
 
 
-## 0.3.2
+## 0.3.2 - 2011-10-18
 
 * Fix :prefix search in PostgreSQL 8.x
 * Disable {:ignoring => :accents} in PostgreSQL 8.x
 
 
-## 0.3.1
+## 0.3.1 - 2011-09-08
 
 * Fix syntax error in generated dmetaphone migration. (Max De Marzi)
 
 
-## 0.3
+## 0.3 - 2011-09-06
 
 * Drop Active Record 2.0 support.
 * Add PgSearch.multisearch for cross-model searching.
@@ -336,16 +336,16 @@
 * Add :any_word option to :tsearch which uses OR between query terms instead
   of AND. (Fernando Espinosa)
 
-## 0.2.2
+## 0.2.2 - 2013-07-08
 
 * Fix a compatibility issue between Ruby 1.8.7 and 1.9.3 when using Rails 2
   (James Badger)
 
-## 0.2.1
+## 0.2.1 - 2011-12-15
 
 * Backport support for searching against tsvector columns (Kris Hicks)
 
-## 0.2
+## 0.2 - 2011-05-11
 
 * Set dictionary to :simple by default for :tsearch. Before it was unset,
   which would fall back to PostgreSQL's default dictionary, usually
@@ -354,22 +354,22 @@
 * Improve performance of :associated_against by only doing one INNER JOIN
   per association
 
-## 0.1.1
+## 0.1.1 - 2011-01-20
 
 * Fix a bug with dmetaphone searches containing " w " (which dmetaphone maps
   to an empty string)
 
-## 0.1
+## 0.1 - 2011-01-18
 
 * Change API to {:ignoring => :accents} from {:normalizing => :diacritics}
 * Improve documentation
 * Fix bug where :associated_against would not work without an :against
   present
 
-## 0.0.2
+## 0.0.2 - 2011-01-14
 
 * Fix gem ownership.
 
-## 0.0.1
+## 0.0.1 - 2011-01-14
 
 * Initial release.

--- a/lib/pg_search/version.rb
+++ b/lib/pg_search/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module PgSearch
-  VERSION = "2.3.8"
+  VERSION = "2.4.0"
 end


### PR DESCRIPTION
Prepare the 2.4.0 release without tagging or publishing it.

- Set the gem version to 2.4.0.
- Finalize the Active Record 7.2 support-floor and Arel refactor notes.
- Add RubyGems publication dates to historical releases and mark 2.4.0 as unreleased until publication.
